### PR TITLE
Feature: Added Tag-based Navigation Mode

### DIFF
--- a/src/components/card-browser/card-browser.tsx
+++ b/src/components/card-browser/card-browser.tsx
@@ -1,195 +1,243 @@
-import './card-browser.scss';
+import "./card-browser.scss";
 import * as React from "react";
 import { FolderSection } from "../section/folder-section";
 import { StateSection } from "../section/state-section";
 import { StatelessSection } from "../section/stateless-section";
-import { TFile, TFolder } from 'obsidian';
-import { BackButtonAndPath } from '../back-button-and-path/back-button-and-path';
-import { filterSectionsByString, getSortedSectionsInFolder, orderItemsInSections } from 'src/logic/folder-processes';
-import { CardBrowserViewEState, CardBrowserViewState, PartialCardBrowserViewState } from 'src/views/card-browser-view/card-browser-view';
-import { v4 as uuidv4 } from 'uuid';
-import { registerCardBrowserContextMenu } from 'src/context-menus/card-browser-context-menu';
-import { getGlobals } from 'src/logic/stores';
-import { SearchInput } from '../search-input/search-input';
-import classNames from 'classnames';
-import { CardBrowserFloatingMenu } from '../card-browser-floating-menu/card-browser-floating-menu';
+import { TFile, TFolder } from "obsidian";
+import { BackButtonAndPath } from "../back-button-and-path/back-button-and-path";
+import {
+  filterSectionsByString,
+  getSortedSectionsInFolder,
+  orderItemsInSections,
+} from "src/logic/folder-processes";
+// NEW: Import tag processes
+import { getSortedSectionsByTag, TagFolder } from "src/logic/tag-processes";
+import {
+  CardBrowserViewEState,
+  CardBrowserViewState,
+  PartialCardBrowserViewState,
+} from "src/views/card-browser-view/card-browser-view";
+import { v4 as uuidv4 } from "uuid";
+import { registerCardBrowserContextMenu } from "src/context-menus/card-browser-context-menu";
+import { getGlobals } from "src/logic/stores";
+import { SearchInput } from "../search-input/search-input";
+import classNames from "classnames";
+import { CardBrowserFloatingMenu } from "../card-browser-floating-menu/card-browser-floating-menu";
 
 //////////
 //////////
 
 export const CardBrowserContext = React.createContext<{
-    folder: null | TFolder,
-    lastTouchedFilePath: string,
-    rememberLastTouchedFile: (file: TFile) => void,
-    openFolderInSameLeaf: (folder: TFolder) => void,
-    rerender: () => void,
+  // Changed from TFolder to any to accept TagFolder without complex Typescript refactoring
+  folder: null | TFolder | any;
+  lastTouchedFilePath: string;
+  rememberLastTouchedFile: (file: TFile) => void;
+  openFolderInSameLeaf: (folder: TFolder | any) => void;
+  rerender: () => void;
 }>({
-    folder: null,
-    lastTouchedFilePath: '',
-    rememberLastTouchedFile: () => {},
-    openFolderInSameLeaf: () => {},
-    rerender: () => {},
+  folder: null,
+  lastTouchedFilePath: "",
+  rememberLastTouchedFile: () => {},
+  openFolderInSameLeaf: () => {},
+  rerender: () => {},
 });
 
 export interface CardBrowserHandlers {
-    rerender: Function,
+  rerender: Function;
 }
 // export const cardBrowserHandlers = atom<CardBrowserHandlers>()
 
 interface CardBrowserProps {
-    path: string,
-    setViewStateWithHistory: (viewState: PartialCardBrowserViewState) => void,
-    rememberLastTouchedFilepath: (filepath: string) => {},
-    resetLastTouchedFilepath: Function,
-    getViewStates: () => {state: CardBrowserViewState, eState: CardBrowserViewEState},
-    passBackHandlers: (handlers: CardBrowserHandlers) => void,
+  path: string;
+  setViewStateWithHistory: (viewState: PartialCardBrowserViewState) => void;
+  rememberLastTouchedFilepath: (filepath: string) => {};
+  resetLastTouchedFilepath: Function;
+  getViewStates: () => {
+    state: CardBrowserViewState;
+    eState: CardBrowserViewEState;
+  };
+  passBackHandlers: (handlers: CardBrowserHandlers) => void;
 }
 
 export const CardBrowser = (props: CardBrowserProps) => {
-    const {plugin} = getGlobals();
-    const [viewInstanceId] = React.useState<string>(uuidv4());
-    const [refreshId, setRefreshId] = React.useState<number>(uuidv4());
-    const [searchActive, setSearchActive] = React.useState<boolean>(false);
-    const [searchStr, setSearchStr] = React.useState<string>('');
-    const {state, eState} = props.getViewStates();
-    const browserRef = React.useRef(null);
+  const { plugin } = getGlobals();
+  const [viewInstanceId] = React.useState<string>(uuidv4());
+  const [refreshId, setRefreshId] = React.useState<number>(uuidv4());
+  const [searchActive, setSearchActive] = React.useState<boolean>(false);
+  const [searchStr, setSearchStr] = React.useState<string>("");
+  const { state, eState } = props.getViewStates();
+  const browserRef = React.useRef(null);
 
-    // const setCardBrowserHandlers = useSetAtom(cardBrowserHandlers);
+  // const setCardBrowserHandlers = useSetAtom(cardBrowserHandlers);
 
-    // const [files, setFiles] = useState
-    const v = plugin.app.vault;
-    // const [path, setPath] = React.useState(props.path);
-    const initialFolder = v.getFolderByPath(state.path) || v.getRoot(); // TODO: Check this is valid?
-    let sectionsOfItems = getSortedSectionsInFolder(initialFolder);
-    
-    filterSectionsByString(sectionsOfItems, searchStr);
-    
-    const lastTouchedFilePath = eState?.lastTouchedFilePath || '';
+  // const [files, setFiles] = useState
+  const v = plugin.app.vault;
 
-    // on mount
-    React.useEffect( () => {
-        if(!plugin) return;
-        
-        props.passBackHandlers({
-            rerender,
-        })
-        plugin.addGlobalFileDependant(`card-browser_${viewInstanceId}`, rerender);
+  // NEW: Logic to switch between Tag mode and Folder mode
+  let initialFolder: any;
+  let sectionsOfItems = [];
 
-        // NOTE: When the view is changed to something else, this is never given the chance to unmount.
-        // Must removeDependant from elsewhere?
-        // return;
+  if (plugin.settings.browserMode === "tag") {
+    // TAG MODE
+    // Treat path as tag path (e.g. "project/marketing")
+    const tagPath =
+      state.path === "/" || state.path === "root" ? "" : state.path;
 
-        if(plugin && browserRef.current) {
-            registerCardBrowserContextMenu(browserRef.current, initialFolder, {
-                openFile: () => {}, // TODO: maybe remove this... it used to be a function
-                getCurFolder,
-            });
-        }
-        
-    },[])
+    sectionsOfItems = getSortedSectionsByTag(tagPath);
 
-    const getCurFolder = (): TFolder => {
-        const curFolder = v.getFolderByPath(props.getViewStates().state.path) || v.getRoot();
-        return curFolder;
-    }
-
-    function rerender() {
-        setRefreshId(uuidv4());
-    }
-    
-    return (
-        <CardBrowserContext.Provider value={{
-            folder: initialFolder,
-            lastTouchedFilePath,
-            openFolderInSameLeaf,
-            rememberLastTouchedFile,
-            rerender,
-        }}>
-            <div
-                ref = {browserRef}
-                className = 'ddc_pb_browser'
-            >
-                <BackButtonAndPath
-                    folder = {initialFolder}
-                    onBackClick = {openParentFolder}
-                    onFolderClick = { (folder: TFolder) => openFolderInSameLeaf(folder)}
-                />
-                <div
-                    className = {classNames([
-                        'ddc_pb_section',
-                        'ddc_pb_nav-and-filter-section'
-                    ])}
-                >
-                    {sectionsOfItems.map( (section) => (
-                        <React.Fragment key={section.title}>
-                            {section.type === "folders" && (<>
-                                <FolderSection section={section}/>
-                            </>)}
-                        </React.Fragment>
-                    ))}
-                    <SearchInput
-                        searchActive = {searchActive}
-                        onChange = {setSearchStr}
-                        hideSearchInput = {() => setSearchActive(false)}
-                        showSearchInput = {() => setSearchActive(true)}
-                    />
-                </div>
-                <div>
-                    {sectionsOfItems.map( (section, index) => (
-                        <React.Fragment key={section.title}>
-                            {section.type !== "folders" && (
-                                (!searchActive || (searchActive && section.items.length > 0)) && (
-                                    <div>
-                                        {section.type === "state" && (
-                                            <StateSection section={section}/>
-                                        )}
-                                        {section.type === "stateless" && (
-                                            <StatelessSection section={section}/>
-                                        )}
-                                    </div>
-                                )
-                            )}
-                        </React.Fragment>
-                    ))}
-                </div>
-                <CardBrowserFloatingMenu
-                    folder = {initialFolder}
-                    searchActive = {searchActive}
-                    activateSearch = {() => setSearchActive(true)}
-                    deactivateSearch = {() => setSearchActive(false)}
-                />
-            </div>
-        </CardBrowserContext.Provider>
+    // Create a virtual folder object so the UI components (Breadcrumbs/Buttons) have something to read
+    initialFolder = new TagFolder(
+      tagPath === "" ? "All Tags" : tagPath.split("/").pop() || "Tag",
+      tagPath,
+      v,
     );
+  } else {
+    // FOLDER MODE (Original Logic)
+    initialFolder = v.getFolderByPath(state.path) || v.getRoot();
+    sectionsOfItems = getSortedSectionsInFolder(initialFolder);
+  }
 
-    ////////
+  // Filter whatever we found
+  filterSectionsByString(sectionsOfItems, searchStr);
 
-    function rememberLastTouchedFile(file: TFile) {
-        props.rememberLastTouchedFilepath(file.path);
+  const lastTouchedFilePath = eState?.lastTouchedFilePath || "";
+
+  // on mount
+  React.useEffect(() => {
+    if (!plugin) return;
+
+    props.passBackHandlers({
+      rerender,
+    });
+    plugin.addGlobalFileDependant(`card-browser_${viewInstanceId}`, rerender);
+
+    // NOTE: When the view is changed to something else, this is never given the chance to unmount.
+    // Must removeDependant from elsewhere?
+    // return;
+
+    if (plugin && browserRef.current) {
+      // Only register context menu if we are in folder mode (or handle tag mode inside context menu logic later)
+      // For now, passing initialFolder (which might be TagFolder) might limit functionality of the context menu
+      registerCardBrowserContextMenu(browserRef.current, initialFolder, {
+        openFile: () => {}, // TODO: maybe remove this... it used to be a function
+        getCurFolder,
+      });
+    }
+  }, []);
+
+  const getCurFolder = (): TFolder => {
+    const curFolder =
+      v.getFolderByPath(props.getViewStates().state.path) || v.getRoot();
+    return curFolder;
+  };
+
+  function rerender() {
+    setRefreshId(uuidv4());
+  }
+
+  return (
+    <CardBrowserContext.Provider
+      value={{
+        folder: initialFolder,
+        lastTouchedFilePath,
+        openFolderInSameLeaf,
+        rememberLastTouchedFile,
+        rerender,
+      }}
+    >
+      <div ref={browserRef} className="ddc_pb_browser">
+        <BackButtonAndPath
+          folder={initialFolder}
+          onBackClick={openParentFolder}
+          onFolderClick={(folder: TFolder) => openFolderInSameLeaf(folder)}
+        />
+        <div
+          className={classNames([
+            "ddc_pb_section",
+            "ddc_pb_nav-and-filter-section",
+          ])}
+        >
+          {sectionsOfItems.map((section) => (
+            <React.Fragment key={section.title}>
+              {section.type === "folders" && (
+                <>
+                  <FolderSection section={section} />
+                </>
+              )}
+            </React.Fragment>
+          ))}
+          <SearchInput
+            searchActive={searchActive}
+            onChange={setSearchStr}
+            hideSearchInput={() => setSearchActive(false)}
+            showSearchInput={() => setSearchActive(true)}
+          />
+        </div>
+        <div>
+          {sectionsOfItems.map((section, index) => (
+            <React.Fragment key={section.title}>
+              {section.type !== "folders" &&
+                (!searchActive ||
+                  (searchActive && section.items.length > 0)) && (
+                  <div>
+                    {section.type === "state" && (
+                      <StateSection section={section} />
+                    )}
+                    {section.type === "stateless" && (
+                      <StatelessSection section={section} />
+                    )}
+                  </div>
+                )}
+            </React.Fragment>
+          ))}
+        </div>
+        <CardBrowserFloatingMenu
+          folder={initialFolder}
+          searchActive={searchActive}
+          activateSearch={() => setSearchActive(true)}
+          deactivateSearch={() => setSearchActive(false)}
+        />
+      </div>
+    </CardBrowserContext.Provider>
+  );
+
+  ////////
+
+  function rememberLastTouchedFile(file: TFile) {
+    props.rememberLastTouchedFilepath(file.path);
+  }
+
+  // Updated to accept TFolder OR TagFolder
+  function openFolderInSameLeaf(nextFolder: any) {
+    const { plugin } = getGlobals();
+    let { workspace } = plugin.app;
+    let leaf = workspace.getMostRecentLeaf();
+
+    // TODO: Unwrap this (remove if)??
+    if (leaf) {
+      props.resetLastTouchedFilepath();
     }
 
-    function openFolderInSameLeaf(nextFolder: TFolder) {
-        const {plugin} = getGlobals();
-        let { workspace } = plugin.app;
-        let leaf = workspace.getMostRecentLeaf();
-        
-        // TODO: Unwrap this (remove if)??
-        if(leaf) {
-            props.resetLastTouchedFilepath();
-        }
-        
-        props.setViewStateWithHistory({
-            path: nextFolder.path,
-        });
-    }
-    
-    function openParentFolder() {
-        const nextFolder = initialFolder.parent;
-        if(!nextFolder) return;
-        openFolderInSameLeaf(nextFolder);
-    }
+    props.setViewStateWithHistory({
+      path: nextFolder.path,
+    });
+  }
 
-
+  // Updated logic to handle "Parent" of a Tag path (e.g. #tag/sub -> #tag)
+  function openParentFolder() {
+    if (plugin.settings.browserMode === "tag") {
+      if (!state.path || state.path === "/" || state.path === "") return;
+      const segments = state.path.split("/");
+      segments.pop(); // remove last segment
+      const nextPath = segments.join("/");
+      props.setViewStateWithHistory({ path: nextPath });
+    } else {
+      // Original Folder Logic
+      const nextFolder = initialFolder.parent;
+      if (!nextFolder) return;
+      openFolderInSameLeaf(nextFolder);
+    }
+  }
 };
 
 //////////

--- a/src/logic/tag-processes.ts
+++ b/src/logic/tag-processes.ts
@@ -1,0 +1,106 @@
+import { TFile } from "obsidian";
+import { getGlobals } from "./stores";
+import { getStateSettings, orderSections } from "./section-processes";
+import { getFileStateName } from "./frontmatter-processes";
+
+// A fake folder object so the UI doesn't break
+export class TagFolder {
+  name: string;
+  path: string;
+  vault: any;
+  constructor(name: string, path: string, vault: any) {
+    this.name = name;
+    this.path = path;
+    this.vault = vault;
+  }
+}
+
+export const getSortedSectionsByTag = (currentTagPath: string = "") => {
+  const { plugin } = getGlobals();
+  const files = plugin.app.vault.getMarkdownFiles();
+
+  const itemsBySection: Record<string, any[]> = {};
+  const subTags = new Set<string>();
+
+  files.forEach((file: TFile) => {
+    const cache = plugin.app.metadataCache.getFileCache(file);
+    if (!cache) return;
+
+    // Get tags from frontmatter and body
+    const tags = getAllTags(cache);
+
+    // Check if file matches current tag path
+    const isInTag =
+      currentTagPath === ""
+        ? true
+        : tags.some(
+            (t) =>
+              t === `#${currentTagPath}` || t.startsWith(`#${currentTagPath}/`),
+          );
+
+    if (!isInTag) return;
+
+    // Find sub-tags (folders)
+    tags.forEach((tag) => {
+      const tagClean = tag.substring(1); // remove #
+      if (tagClean.startsWith(currentTagPath) && tagClean !== currentTagPath) {
+        const relative = currentTagPath
+          ? tagClean.substring(currentTagPath.length + 1)
+          : tagClean;
+        subTags.add(relative.split("/")[0]);
+      }
+    });
+
+    // Add file if it is in this exact tag
+    if (tags.includes(`#${currentTagPath}`) || currentTagPath === "") {
+      const state = getFileStateName(file) || " ";
+      if (!itemsBySection[state]) itemsBySection[state] = [];
+      itemsBySection[state].push(file);
+    }
+  });
+
+  // Create virtual folders for sub-tags
+  itemsBySection["folders"] = Array.from(subTags).map((tagName) => {
+    const fullPath = currentTagPath ? `${currentTagPath}/${tagName}` : tagName;
+    return new TagFolder(tagName, fullPath, plugin.app.vault);
+  });
+
+  // Build Sections (Reuse existing logic structure)
+  let itemsBySectionArr = [];
+  for (const [key, value] of Object.entries(itemsBySection)) {
+    if (key === "folders") {
+      itemsBySectionArr.push({
+        title: key,
+        type: "folders",
+        items: value,
+        settings: plugin.settings.folders,
+      });
+    } else if (key == " ") {
+      itemsBySectionArr.push({
+        title: key,
+        type: "stateless",
+        items: value,
+        settings: plugin.settings.stateless,
+      });
+    } else {
+      itemsBySectionArr.push({
+        title: key,
+        type: "state",
+        items: value,
+        settings: getStateSettings(key),
+      });
+    }
+  }
+
+  return orderSections(itemsBySectionArr);
+};
+
+function getAllTags(cache: any): string[] {
+  let tags = new Set<string>();
+  if (cache.frontmatter?.tags) {
+    const tf = cache.frontmatter.tags;
+    (Array.isArray(tf) ? tf : [tf]).forEach((t) => tags.add(`#${t}`));
+  }
+  if (cache.tags) cache.tags.forEach((t: any) => tags.add(t.tag));
+  return Array.from(tags);
+}

--- a/src/tabs/settings-tab/settings-tab.ts
+++ b/src/tabs/settings-tab/settings-tab.ts
@@ -1,292 +1,375 @@
-import { insertStateEditor } from 'src/components/state-editor/state-editor';
-import 'src/shared/settings.scss';
+import { insertStateEditor } from "src/components/state-editor/state-editor";
+import "src/shared/settings.scss";
 import { PluginSettingTab, Setting } from "obsidian";
 import MyPlugin from "src/main";
 import { ConfirmationModal } from "src/modals/confirmation-modal/confirmation-modal";
-import { folderPathSanitize } from 'src/utils/string-processes';
-import { getGlobals } from 'src/logic/stores';
-import { StateSettings, StateViewMode, PrioritySettings } from 'src/types/types-map';
+import { folderPathSanitize } from "src/utils/string-processes";
+import { getGlobals } from "src/logic/stores";
+import {
+  StateSettings,
+  StateViewMode,
+  PrioritySettings,
+} from "src/types/types-map";
 
 /////////
 /////////
 
 export function registerSettingsTab() {
-	const {plugin} = getGlobals();
-	plugin.addSettingTab(new MySettingsTab());
+  const { plugin } = getGlobals();
+  plugin.addSettingTab(new MySettingsTab());
 }
 
 export class MySettingsTab extends PluginSettingTab {
-    plugin: MyPlugin;
+  plugin: MyPlugin;
 
-    constructor() {
-        const {plugin} = getGlobals();
-        super(plugin.app, plugin);
-        this.plugin = plugin;
-    }
+  constructor() {
+    const { plugin } = getGlobals();
+    super(plugin.app, plugin);
+    this.plugin = plugin;
+  }
 
-	display = (): void => {
-		const {containerEl} = this;
+  display = (): void => {
+    const { containerEl } = this;
 
-		containerEl.empty();
+    containerEl.empty();
 
-		// insertPrereleaseWarning(containerEl);
-		// containerEl.createEl('hr');
-		
-		insertMoreInfoLinks(containerEl);
-		insertAccessSettings(containerEl, this.display);
-		insertStateSettings(containerEl, this.display);
-		insertPrioritySettings(containerEl, this.display);
-		insertNoteSettings(containerEl, this.display);
-			
-		// TODO: Collapsible change log
-		// containerEl.createEl('p', {
-		// 	text: 'Alpha v0.0.359 changes',
-		// 	cls: 'ddc_pb_text-warning',
-		// });		
-		
-		// insertAccessSettings(containerEl, this.plugin, () => this.display());
-	
-		new Setting(containerEl)
-			.addButton( (button) => {
-				button.setButtonText('Reset settings');
-        button.onClick(() => {
-            new ConfirmationModal({
-                title: 'Please confirm',
-                message: 'Revert all Project Browser settings to defaults??',
-                confirmLabel: 'Reset settings',
-                confirmAction: async () => {
-                    await this.plugin.resetSettings();
-                    this.display();
-                }
-            }).open();
-        })
-			})
-		
+    // insertPrereleaseWarning(containerEl);
+    // containerEl.createEl('hr');
 
-	}
+    insertMoreInfoLinks(containerEl);
+    insertAccessSettings(containerEl, this.display);
+    insertStateSettings(containerEl, this.display);
+    insertPrioritySettings(containerEl, this.display);
+    insertNoteSettings(containerEl, this.display);
+
+    // TODO: Collapsible change log
+    // containerEl.createEl('p', {
+    // 	text: 'Alpha v0.0.359 changes',
+    // 	cls: 'ddc_pb_text-warning',
+    // });
+
+    // insertAccessSettings(containerEl, this.plugin, () => this.display());
+
+    new Setting(containerEl).addButton((button) => {
+      button.setButtonText("Reset settings");
+      button.onClick(() => {
+        new ConfirmationModal({
+          title: "Please confirm",
+          message: "Revert all Project Browser settings to defaults??",
+          confirmLabel: "Reset settings",
+          confirmAction: async () => {
+            await this.plugin.resetSettings();
+            this.display();
+          },
+        }).open();
+      });
+    });
+  };
 }
 
 function insertMoreInfoLinks(containerEl: HTMLElement) {
-	const sectionEl = containerEl.createDiv('ddc_pb_settings-section');
-	sectionEl.createEl('p', { text: `For information on this plugin's development, visit the links below. Feel free to leave comments in the development diaries on YouTube.` });
-	const list = sectionEl.createEl('ul');
-	list.createEl('li').createEl('a', {
-		href: 'https://github.com/daledesilva/obsidian_project-browser/releases',
-		text: 'Latest changes'
-	});
-	list.createEl('li').createEl('a', {
-		href: 'https://github.com/daledesilva/obsidian_project-browser',
-		text: 'Roadmap'
-	});
-	list.createEl('li').createEl('a', {
-		href: 'https://youtube.com/playlist?list=PLAiv7XV4xFx3_JUHGUp_vrqturMTsoBUZ&si=VO6nlt2v0KG224cY',
-		text: 'Development diaries.'
-	});
-	list.createEl('li').createEl('a', {
-		href: 'https://github.com/daledesilva/obsidian_project-browser/issues',
-		text: 'Request feature / Report bug.'
-	});
+  const sectionEl = containerEl.createDiv("ddc_pb_settings-section");
+  sectionEl.createEl("p", {
+    text: `For information on this plugin's development, visit the links below. Feel free to leave comments in the development diaries on YouTube.`,
+  });
+  const list = sectionEl.createEl("ul");
+  list.createEl("li").createEl("a", {
+    href: "https://github.com/daledesilva/obsidian_project-browser/releases",
+    text: "Latest changes",
+  });
+  list.createEl("li").createEl("a", {
+    href: "https://github.com/daledesilva/obsidian_project-browser",
+    text: "Roadmap",
+  });
+  list.createEl("li").createEl("a", {
+    href: "https://youtube.com/playlist?list=PLAiv7XV4xFx3_JUHGUp_vrqturMTsoBUZ&si=VO6nlt2v0KG224cY",
+    text: "Development diaries.",
+  });
+  list.createEl("li").createEl("a", {
+    href: "https://github.com/daledesilva/obsidian_project-browser/issues",
+    text: "Request feature / Report bug.",
+  });
 }
 
 function insertAccessSettings(containerEl: HTMLElement, refresh: Function) {
-	const {plugin} = getGlobals();
+  const { plugin } = getGlobals();
 
-	const sectionEl = containerEl.createDiv('ddc_pb_settings-section');
+  const sectionEl = containerEl.createDiv("ddc_pb_settings-section");
 
-	new Setting(sectionEl)
-		.setClass('ddc_pb_setting')
-		.setName('Replace empty tab')
-		.setDesc('Create a new, empty tab to access the Project Browser.')
-		.addToggle((toggle) => {
-			toggle.setValue(plugin.settings.access.replaceNewTab);
-			toggle.onChange(async (value) => {
-				plugin.settings.access.replaceNewTab = value;
-				await plugin.saveSettings();
-				refresh();
-			});
-		});
+  // NEW: Browser Mode Setting
+  new Setting(sectionEl)
+    .setClass("ddc_pb_setting")
+    .setName("Browser Mode")
+    .setDesc(
+      "Choose between Folder-based or Tag-based navigation. (Requires refresh)",
+    )
+    .addDropdown((dropdown) => {
+      dropdown.addOption("folder", "Folders");
+      dropdown.addOption("tag", "Tags");
+      dropdown.setValue(plugin.settings.browserMode || "folder");
+      dropdown.onChange(async (value) => {
+        plugin.settings.browserMode = value as "folder" | "tag";
+        await plugin.saveSettings();
+        refresh();
+      });
+    });
 
-	new Setting(sectionEl)
-		.setClass('ddc_pb_setting')
-		.setName('Enable ribbon icon')
-		.setDesc('Click an icon in the Obsidian ribbon menu bar to open the Project Browser in a new tab.')
-		.addToggle((toggle) => {
-			toggle.setValue(plugin.settings.access.enableRibbonIcon);
-			toggle.onChange(async (value) => {
-				plugin.settings.access.enableRibbonIcon = value;
-				await plugin.saveSettings();
-				refresh();
-			});
-		});
+  new Setting(sectionEl)
+    .setClass("ddc_pb_setting")
+    .setName("Replace empty tab")
+    .setDesc("Create a new, empty tab to access the Project Browser.")
+    .addToggle((toggle) => {
+      toggle.setValue(plugin.settings.access.replaceNewTab);
+      toggle.onChange(async (value) => {
+        plugin.settings.access.replaceNewTab = value;
+        await plugin.saveSettings();
+        refresh();
+      });
+    });
 
-	new Setting(sectionEl)
-		.setClass('ddc_pb_setting')
-		.setName('Enable command')
-		.setDesc('Run a command from the Command Palette at any time to open the Project Browser in a new tab.')
-		.addToggle((toggle) => {
-			toggle.setValue(plugin.settings.access.enableCommand);
-			toggle.onChange(async (value) => {
-				plugin.settings.access.enableCommand = value;
-				await plugin.saveSettings();
-				refresh();
-			});
-		});
+  new Setting(sectionEl)
+    .setClass("ddc_pb_setting")
+    .setName("Enable ribbon icon")
+    .setDesc(
+      "Click an icon in the Obsidian ribbon menu bar to open the Project Browser in a new tab.",
+    )
+    .addToggle((toggle) => {
+      toggle.setValue(plugin.settings.access.enableRibbonIcon);
+      toggle.onChange(async (value) => {
+        plugin.settings.access.enableRibbonIcon = value;
+        await plugin.saveSettings();
+        refresh();
+      });
+    });
 
-	new Setting(sectionEl)
-		.setClass('ddc_pb_setting')
-		.setName('Launch folder')
-		.setDesc('Which folder should new Project Browser tabs open in.')
-		.addText((text) => {
-			text.setValue(plugin.settings.access.launchFolder);
-			text.inputEl.addEventListener( 'blur', (e) => {
-				const safeValue = folderPathSanitize(text.getValue());
-				text.setValue(safeValue);
-				plugin.settings.access.launchFolder = safeValue;
-				plugin.saveSettings();
-			})
-		})
+  new Setting(sectionEl)
+    .setClass("ddc_pb_setting")
+    .setName("Enable command")
+    .setDesc(
+      "Run a command from the Command Palette at any time to open the Project Browser in a new tab.",
+    )
+    .addToggle((toggle) => {
+      toggle.setValue(plugin.settings.access.enableCommand);
+      toggle.onChange(async (value) => {
+        plugin.settings.access.enableCommand = value;
+        await plugin.saveSettings();
+        refresh();
+      });
+    });
 
-	new Setting(sectionEl)
-		.setClass('ddc_pb_setting')
-		.setName('Use Aliases')
-		.setDesc(`Display the first alias of a file as it's name in the Project Browser if available.`)
-		.addToggle((toggle) => {
-			toggle.setValue(plugin.settings.useAliases);
-			toggle.onChange(async (value) => {
-				plugin.settings.useAliases = value;
-				await plugin.saveSettings();
-				refresh();
-			});
-		})
+  new Setting(sectionEl)
+    .setClass("ddc_pb_setting")
+    .setName("Launch folder")
+    .setDesc("Which folder should new Project Browser tabs open in.")
+    .addText((text) => {
+      text.setValue(plugin.settings.access.launchFolder);
+      text.inputEl.addEventListener("blur", (e) => {
+        const safeValue = folderPathSanitize(text.getValue());
+        text.setValue(safeValue);
+        plugin.settings.access.launchFolder = safeValue;
+        plugin.saveSettings();
+      });
+    });
+
+  new Setting(sectionEl)
+    .setClass("ddc_pb_setting")
+    .setName("Use Aliases")
+    .setDesc(
+      `Display the first alias of a file as it's name in the Project Browser if available.`,
+    )
+    .addToggle((toggle) => {
+      toggle.setValue(plugin.settings.useAliases);
+      toggle.onChange(async (value) => {
+        plugin.settings.useAliases = value;
+        await plugin.saveSettings();
+        refresh();
+      });
+    });
 }
 
 function insertStateSettings(containerEl: HTMLElement, refresh: Function) {
-	const {plugin} = getGlobals();
-	const sectionEl = containerEl.createDiv('ddc_pb_settings-section ddc_pb_controls-section');
-	sectionEl.createEl('h2', { text: 'States' });
-	sectionEl.createEl('p', { text: `This is the list of categories that Project Browser will help assign notes and group by in the Browser view. Add new states and drag them to reorder or delete.` });
-	// sectionEl.createEl('p', { text: `Notes states will appear in reverse order in the Browser view so that more progressed notes are shown higher. Hidden states will not show.` });
+  const { plugin } = getGlobals();
+  const sectionEl = containerEl.createDiv(
+    "ddc_pb_settings-section ddc_pb_controls-section",
+  );
+  sectionEl.createEl("h2", { text: "States" });
+  sectionEl.createEl("p", {
+    text: `This is the list of categories that Project Browser will help assign notes and group by in the Browser view. Add new states and drag them to reorder or delete.`,
+  });
+  // sectionEl.createEl('p', { text: `Notes states will appear in reverse order in the Browser view so that more progressed notes are shown higher. Hidden states will not show.` });
 
-	new Setting(sectionEl)
-		.setClass('ddc_pb_setting')
-		.setName('Loop states')
-		.setDesc('When pressing the hotkeys to step states forward or backward, should it cycle back to the first or last state when the end is reached?')
-		.addToggle((toggle) => {
-			toggle.setValue(plugin.settings.loopStatesWhenCycling);
-			toggle.onChange(async (value) => {
-				plugin.settings.loopStatesWhenCycling = value;
-				await plugin.saveSettings();
-				refresh();
-			});
-		});
+  new Setting(sectionEl)
+    .setClass("ddc_pb_setting")
+    .setName("Loop states")
+    .setDesc(
+      "When pressing the hotkeys to step states forward or backward, should it cycle back to the first or last state when the end is reached?",
+    )
+    .addToggle((toggle) => {
+      toggle.setValue(plugin.settings.loopStatesWhenCycling);
+      toggle.onChange(async (value) => {
+        plugin.settings.loopStatesWhenCycling = value;
+        await plugin.saveSettings();
+        refresh();
+      });
+    });
 
-	insertStateEditor(sectionEl);
+  insertStateEditor(sectionEl);
 
-	new Setting(sectionEl)
-		.setClass('ddc_pb_setting')
-		.setName('Default state')
-		.addDropdown((dropdown) => {
-			function updateDropdownOptions() {
-				const options: Record<string, string> = {};
-				Object.values(plugin.settings.states.visible).map((stateSettings: StateSettings) => {
-					options[stateSettings.name] = stateSettings.name;
-				});
-				Object.values(plugin.settings.states.hidden).map((stateSettings: StateSettings) => {
-					options[stateSettings.name] = stateSettings.name;
-				});
-				options['(None)'] = '(None)';
-				dropdown.selectEl.empty();
-				dropdown.addOptions(options)
-			}
-			updateDropdownOptions();
-			dropdown.selectEl.addEventListener('focus', (event) => {
-				updateDropdownOptions();
-			});
-			dropdown.selectEl.addEventListener('change', (event) => {
-				plugin.settings.defaultState = dropdown.getValue() == '(None)' ? undefined : dropdown.getValue() as string;
-				plugin.saveSettings();
-			});
-		})
+  new Setting(sectionEl)
+    .setClass("ddc_pb_setting")
+    .setName("Default state")
+    .addDropdown((dropdown) => {
+      function updateDropdownOptions() {
+        const options: Record<string, string> = {};
+        Object.values(plugin.settings.states.visible).map(
+          (stateSettings: StateSettings) => {
+            options[stateSettings.name] = stateSettings.name;
+          },
+        );
+        Object.values(plugin.settings.states.hidden).map(
+          (stateSettings: StateSettings) => {
+            options[stateSettings.name] = stateSettings.name;
+          },
+        );
+        options["(None)"] = "(None)";
+        dropdown.selectEl.empty();
+        dropdown.addOptions(options);
+      }
+      updateDropdownOptions();
+      dropdown.selectEl.addEventListener("focus", (event) => {
+        updateDropdownOptions();
+      });
+      dropdown.selectEl.addEventListener("change", (event) => {
+        plugin.settings.defaultState =
+          dropdown.getValue() == "(None)"
+            ? undefined
+            : (dropdown.getValue() as string);
+        plugin.saveSettings();
+      });
+    });
 }
 
 function insertPrioritySettings(containerEl: HTMLElement, refresh: Function) {
-	const {plugin} = getGlobals();
-	const sectionEl = containerEl.createDiv('ddc_pb_settings-section ddc_pb_controls-section');
-	sectionEl.createEl('h2', { text: 'Priorities' });
-	sectionEl.createEl('p', { text: `Files can be given high or low priorities from within the browser panel. This can make notes appear with different styling or as grouped by priority.` });
+  const { plugin } = getGlobals();
+  const sectionEl = containerEl.createDiv(
+    "ddc_pb_settings-section ddc_pb_controls-section",
+  );
+  sectionEl.createEl("h2", { text: "Priorities" });
+  sectionEl.createEl("p", {
+    text: `Files can be given high or low priorities from within the browser panel. This can make notes appear with different styling or as grouped by priority.`,
+  });
 
-	// Add toggle for treating priorities as links
-	new Setting(sectionEl)
-		.setClass('ddc_pb_setting')
-		.setName('Treat priorities as links')
-		.setDesc('This will input priorities as internal Obsidian links so that they can be opened and will appear in the graph view as nodes.')
-		.addToggle((toggle) => {
-			// Check if any priority has link enabled to set the initial state
-			const hasLinkEnabled = plugin.settings.priorities.some(priority => priority.link);
-			toggle.setValue(hasLinkEnabled);
-			toggle.onChange(async (value) => {
-				// Update all priorities to have the same link setting
-				plugin.settings.priorities.forEach(priority => {
-					priority.link = value;
-				});
-				await plugin.saveSettings();
-				refresh();
-			});
-		});
+  // Add toggle for treating priorities as links
+  new Setting(sectionEl)
+    .setClass("ddc_pb_setting")
+    .setName("Treat priorities as links")
+    .setDesc(
+      "This will input priorities as internal Obsidian links so that they can be opened and will appear in the graph view as nodes.",
+    )
+    .addToggle((toggle) => {
+      // Check if any priority has link enabled to set the initial state
+      const hasLinkEnabled = plugin.settings.priorities.some(
+        (priority) => priority.link,
+      );
+      toggle.setValue(hasLinkEnabled);
+      toggle.onChange(async (value) => {
+        // Update all priorities to have the same link setting
+        plugin.settings.priorities.forEach((priority) => {
+          priority.link = value;
+        });
+        await plugin.saveSettings();
+        refresh();
+      });
+    });
 }
 
 function insertNoteSettings(containerEl: HTMLElement, refresh: Function) {
-	const {plugin} = getGlobals();
-	const sectionEl = containerEl.createDiv('ddc_pb_settings-section ddc_pb_controls-section');
-	sectionEl.createEl('h2', { text: 'Notes' });
-	sectionEl.createEl('p', { text: 'This section defines how Project Browser features are integrated on screen when your markdown notes display.' });
-	new Setting(sectionEl)
-		.setClass('ddc_pb_setting')
-		.setName('Show state menu in notes')
-		.setDesc('This can be toggled any time through a command (Default shortcut: Cmd+Shift+S).')
-		.addToggle((toggle) => {
-			toggle.setValue(plugin.settings.showStateMenu);
-			toggle.onChange(async (value) => {
-				plugin.settings.showStateMenu = value;
-				await plugin.saveSettings();
-				refresh();
-			});
-		});
-
+  const { plugin } = getGlobals();
+  const sectionEl = containerEl.createDiv(
+    "ddc_pb_settings-section ddc_pb_controls-section",
+  );
+  sectionEl.createEl("h2", { text: "Notes" });
+  sectionEl.createEl("p", {
+    text: "This section defines how Project Browser features are integrated on screen when your markdown notes display.",
+  });
+  new Setting(sectionEl)
+    .setClass("ddc_pb_setting")
+    .setName("Show state menu in notes")
+    .setDesc(
+      "This can be toggled any time through a command (Default shortcut: Cmd+Shift+S).",
+    )
+    .addToggle((toggle) => {
+      toggle.setValue(plugin.settings.showStateMenu);
+      toggle.onChange(async (value) => {
+        plugin.settings.showStateMenu = value;
+        await plugin.saveSettings();
+        refresh();
+      });
+    });
 }
 
 function insertDrawingSettings(containerEl: HTMLElement) {
-	const sectionEl = containerEl.createDiv('ddc_pb_settings-section ddc_pb_controls-section');
-	sectionEl.createEl('h2', { text: 'Drawing' });
-	sectionEl.createEl('p', { text: `While editing a Markdown file, run the action 'Insert new hand drawn section' to embed a drawing canvas.` });
+  const sectionEl = containerEl.createDiv(
+    "ddc_pb_settings-section ddc_pb_controls-section",
+  );
+  sectionEl.createEl("h2", { text: "Drawing" });
+  sectionEl.createEl("p", {
+    text: `While editing a Markdown file, run the action 'Insert new hand drawn section' to embed a drawing canvas.`,
+  });
 }
 
 function insertWritingSettings(containerEl: HTMLElement) {
-	const sectionEl = containerEl.createDiv('ddc_pb_settings-section ddc_pb_controls-section');
-	sectionEl.createEl('h2', { text: 'Writing' });
-	sectionEl.createEl('p', { text: `While editing a Markdown file, run the action 'Insert new handwriting section' to embed a section for writing with a stylus.` });
-	insertWritingLimitations(sectionEl);
+  const sectionEl = containerEl.createDiv(
+    "ddc_pb_settings-section ddc_pb_controls-section",
+  );
+  sectionEl.createEl("h2", { text: "Writing" });
+  sectionEl.createEl("p", {
+    text: `While editing a Markdown file, run the action 'Insert new handwriting section' to embed a section for writing with a stylus.`,
+  });
+  insertWritingLimitations(sectionEl);
 }
 
 function insertWritingLimitations(containerEl: HTMLElement) {
-	const sectionEl = containerEl.createDiv('ddc_pb_settings-section ddc_pb_current-limitations-section');
-	const accordion = sectionEl.createEl('details');
-	accordion.createEl('summary', { text: `Notable writing limitations (Expand for details)` });
-	accordion.createEl('p', { text: `Only the last 300 strokes will be visible while writing (Others will dissapear). This is because the plugin currently experiences lag while displaying long amounts of writing that degrades pen fluidity.` });
-	accordion.createEl('p', { text: `All your writing is still saved, however, and will appear in full whenever the embed is locked.` });
+  const sectionEl = containerEl.createDiv(
+    "ddc_pb_settings-section ddc_pb_current-limitations-section",
+  );
+  const accordion = sectionEl.createEl("details");
+  accordion.createEl("summary", {
+    text: `Notable writing limitations (Expand for details)`,
+  });
+  accordion.createEl("p", {
+    text: `Only the last 300 strokes will be visible while writing (Others will dissapear). This is because the plugin currently experiences lag while displaying long amounts of writing that degrades pen fluidity.`,
+  });
+  accordion.createEl("p", {
+    text: `All your writing is still saved, however, and will appear in full whenever the embed is locked.`,
+  });
 }
 
 function insertPrereleaseWarning(containerEl: HTMLElement) {
-	const sectionEl = containerEl.createDiv('ddc_pb_settings-section ddc_pb_prerelease-warning-section');
-	const accordion = sectionEl.createEl('details', {cls: 'ddc_pb_settings-section-warning'});
-	accordion.createEl('summary', { text: `This plugin is in an Alpha state (Expand for details)` });
-	accordion.createEl('p', { text: `What does Alpha mean? Development of products like this plugin often involve moving through multiple different stages (e.g. Alpha, Beta, then Standard Release).` });
-	accordion.createEl('p', { text: `Alpha, the current stage, means that this plugin is in early development and may undergo large changes that break or change previous functionality.` });
-	accordion.createEl('p', { text: `While in Alpha, please exercise caution while using the plugin, however, note that I (The developer of this plugin) am proceeding with caution to help ensure any files created in this version will be compatible or converted to work with future versions (My own vaults depend on it as well).` });
+  const sectionEl = containerEl.createDiv(
+    "ddc_pb_settings-section ddc_pb_prerelease-warning-section",
+  );
+  const accordion = sectionEl.createEl("details", {
+    cls: "ddc_pb_settings-section-warning",
+  });
+  accordion.createEl("summary", {
+    text: `This plugin is in an Alpha state (Expand for details)`,
+  });
+  accordion.createEl("p", {
+    text: `What does Alpha mean? Development of products like this plugin often involve moving through multiple different stages (e.g. Alpha, Beta, then Standard Release).`,
+  });
+  accordion.createEl("p", {
+    text: `Alpha, the current stage, means that this plugin is in early development and may undergo large changes that break or change previous functionality.`,
+  });
+  accordion.createEl("p", {
+    text: `While in Alpha, please exercise caution while using the plugin, however, note that I (The developer of this plugin) am proceeding with caution to help ensure any files created in this version will be compatible or converted to work with future versions (My own vaults depend on it as well).`,
+  });
 }
 
 function insertGenericWarning(containerEl: HTMLElement, text: string) {
-	const sectionEl = containerEl.createDiv('ddc_pb_settings-section ddc_pb_generic-warning-section');
-	const warningEl = sectionEl.createDiv('ddc_pb_settings-section-warning');
-	warningEl.createEl('p', {text});
+  const sectionEl = containerEl.createDiv(
+    "ddc_pb_settings-section ddc_pb_generic-warning-section",
+  );
+  const warningEl = sectionEl.createDiv("ddc_pb_settings-section-warning");
+  warningEl.createEl("p", { text });
 }

--- a/src/types/plugin-settings_0_3_0.ts
+++ b/src/types/plugin-settings_0_3_0.ts
@@ -1,176 +1,184 @@
-import { FolderSectionSettings_0_0_5, StateViewMode_0_0_5 } from "./plugin-settings_0_0_5";
+import {
+  FolderSectionSettings_0_0_5,
+  StateViewMode_0_0_5,
+} from "./plugin-settings_0_0_5";
 
 ////////////////
 ////////////////
 
 // So it's accessible as a const and a type
 export const StateViewOrder_0_3_0 = {
-    AliasOrFilename: 'Alias or Filename',
-    CreationDate: 'Creation Date',
-    ModifiedDate: 'Modified Date',
+  AliasOrFilename: "Alias or Filename",
+  CreationDate: "Creation Date",
+  ModifiedDate: "Modified Date",
 };
-export type StateViewOrder_0_3_0 = typeof StateViewOrder_0_3_0[keyof typeof StateViewOrder_0_3_0];
+export type StateViewOrder_0_3_0 =
+  (typeof StateViewOrder_0_3_0)[keyof typeof StateViewOrder_0_3_0];
 
 export interface StateSettings_0_3_0 {
-	name: string,
-	link?: boolean,
-	defaultViewMode: StateViewMode_0_0_5,
-	defaultViewOrder: StateViewOrder_0_3_0,
-	defaultViewPriorityVisibility: boolean,
-	defaultViewPriorityGrouping: boolean,
+  name: string;
+  link?: boolean;
+  defaultViewMode: StateViewMode_0_0_5;
+  defaultViewOrder: StateViewOrder_0_3_0;
+  defaultViewPriorityVisibility: boolean;
+  defaultViewPriorityGrouping: boolean;
 }
 
 export const DEFAULT_STATE_SETTINGS_0_3_0: StateSettings_0_3_0 = {
-	name: '',
-	link: true,
-	defaultViewMode: 'Simple Cards',
-	defaultViewOrder: 'AliasOrFilename',
-	defaultViewPriorityVisibility: true,
-	defaultViewPriorityGrouping: true,
-}
+  name: "",
+  link: true,
+  defaultViewMode: "Simple Cards",
+  defaultViewOrder: "AliasOrFilename",
+  defaultViewPriorityVisibility: true,
+  defaultViewPriorityGrouping: true,
+};
 
 export interface PrioritySettings_0_3_0 {
-	name: string,
-	link?: boolean,
+  name: string;
+  link?: boolean;
 }
 
 export const DEFAULT_PRIORITY_SETTINGS_0_3_0: PrioritySettings_0_3_0 = {
-	name: '',
-	link: false,
-}
+  name: "",
+  link: false,
+};
 
 /////////////
 
 export interface PluginSettings_0_3_0 {
-	settingsVersion: string,
-	// Helpers
-    onboardingNotices: {
-		welcomeNoticeRead: boolean,
-		lastVersionNoticeRead: string,
-	},
-	//
-	access: {
-		replaceNewTab: boolean,
-		enableRibbonIcon: boolean,
-		enableCommand: boolean,
-		launchFolder: string,
-	}
-	useAliases: boolean,
-	showStateMenu: boolean,
-	loopStatesWhenCycling: boolean,
-	folders: FolderSectionSettings_0_0_5,
-	states: {
-		visible: StateSettings_0_3_0[],	// changed
-		hidden: StateSettings_0_3_0[],	// changed
-	},
-	stateless: StateSettings_0_3_0,	// changed
-	defaultState?: string,
+  settingsVersion: string;
+  // Helpers
+  onboardingNotices: {
+    welcomeNoticeRead: boolean;
+    lastVersionNoticeRead: string;
+  };
+  //
+  access: {
+    replaceNewTab: boolean;
+    enableRibbonIcon: boolean;
+    enableCommand: boolean;
+    launchFolder: string;
+  };
+  useAliases: boolean;
+  showStateMenu: boolean;
+  loopStatesWhenCycling: boolean;
+  // NEW: Add browserMode definition here
+  browserMode: "folder" | "tag";
+  folders: FolderSectionSettings_0_0_5;
+  states: {
+    visible: StateSettings_0_3_0[];
+    hidden: StateSettings_0_3_0[];
+  };
+  stateless: StateSettings_0_3_0;
+  defaultState?: string;
 
-	// Tracked but not exposed in settings
-	priorities: PrioritySettings_0_3_0[],	// new
-	defaultPriority?: string,	// new
+  // Tracked but not exposed in settings
+  priorities: PrioritySettings_0_3_0[];
+  defaultPriority?: string;
 }
 
 /////////////
 
 export const DEFAULT_PLUGIN_SETTINGS_0_3_0: PluginSettings_0_3_0 = {
-	// Helpers
-    onboardingNotices: {
-		welcomeNoticeRead: false,
-		lastVersionNoticeRead: '',
-	},
-	settingsVersion: '0.3.0',	// Settings version aligns with the version number of the plugin it was updated in
-	access: {
-		replaceNewTab: true,
-		enableRibbonIcon: true,
-		enableCommand: true,
-		launchFolder: '/',
-	},
-	useAliases: true,
-	showStateMenu: true,
-	loopStatesWhenCycling: true,
-	folders: {
-		defaultView: 'Small',
-	},
-	states: {
-		visible: [
-			{
-				name: 'Idea',
-				link: true,
-				defaultViewMode: 'Small Cards',
-				defaultViewOrder: 'AliasOrFilename',
-				defaultViewPriorityVisibility: true,
-				defaultViewPriorityGrouping: true,
-			},
-			{
-				name: 'Shortlisted',
-				link: true,
-				defaultViewMode: 'Small Cards',
-				defaultViewOrder: 'AliasOrFilename',
-				defaultViewPriorityVisibility: true,
-				defaultViewPriorityGrouping: true,
-			},
-			{
-				name: 'Drafting',
-				link: true,
-				defaultViewMode: 'Detailed Cards',
-				defaultViewOrder: 'AliasOrFilename',
-				defaultViewPriorityVisibility: true,
-				defaultViewPriorityGrouping: true,
-			},
-			{
-				name: 'Focus',
-				link: true,
-				defaultViewMode: 'Simple Cards',
-				defaultViewOrder: 'AliasOrFilename',
-				defaultViewPriorityVisibility: true,
-				defaultViewPriorityGrouping: true,
-			},
-			{
-				name: 'Final',
-				link: true,
-				defaultViewMode: 'Small Cards',
-				defaultViewOrder: 'ModifiedDate',
-				defaultViewPriorityVisibility: false,
-				defaultViewPriorityGrouping: false,
-			},
-		],
-		hidden: [
-			{
-				name: 'Archived',
-				link: true,
-				defaultViewMode: 'Small Cards',
-				defaultViewOrder: 'ModifiedDate',
-				defaultViewPriorityVisibility: false,
-				defaultViewPriorityGrouping: false,
-			},
-			{
-				name: 'Cancelled',
-				link: true,
-				defaultViewMode: 'Detailed Cards',
-				defaultViewOrder: 'ModifiedDate',
-				defaultViewPriorityVisibility: false,
-				defaultViewPriorityGrouping: false,
-			},
-		],
-	},
-	stateless: {
-		name: '',
-		defaultViewMode: 'List',
-		defaultViewOrder: 'ModifiedDate',
-		defaultViewPriorityVisibility: true,
-		defaultViewPriorityGrouping: true,
-	},
-	defaultState: 'Idea',
+  // Helpers
+  onboardingNotices: {
+    welcomeNoticeRead: false,
+    lastVersionNoticeRead: "",
+  },
+  settingsVersion: "0.3.0",
+  access: {
+    replaceNewTab: true,
+    enableRibbonIcon: true,
+    enableCommand: true,
+    launchFolder: "/",
+  },
+  useAliases: true,
+  showStateMenu: true,
+  loopStatesWhenCycling: true,
+  // NEW: Default to folder mode so existing users don't break
+  browserMode: "folder",
+  folders: {
+    defaultView: "Small",
+  },
+  states: {
+    visible: [
+      {
+        name: "Idea",
+        link: true,
+        defaultViewMode: "Small Cards",
+        defaultViewOrder: "AliasOrFilename",
+        defaultViewPriorityVisibility: true,
+        defaultViewPriorityGrouping: true,
+      },
+      {
+        name: "Shortlisted",
+        link: true,
+        defaultViewMode: "Small Cards",
+        defaultViewOrder: "AliasOrFilename",
+        defaultViewPriorityVisibility: true,
+        defaultViewPriorityGrouping: true,
+      },
+      {
+        name: "Drafting",
+        link: true,
+        defaultViewMode: "Detailed Cards",
+        defaultViewOrder: "AliasOrFilename",
+        defaultViewPriorityVisibility: true,
+        defaultViewPriorityGrouping: true,
+      },
+      {
+        name: "Focus",
+        link: true,
+        defaultViewMode: "Simple Cards",
+        defaultViewOrder: "AliasOrFilename",
+        defaultViewPriorityVisibility: true,
+        defaultViewPriorityGrouping: true,
+      },
+      {
+        name: "Final",
+        link: true,
+        defaultViewMode: "Small Cards",
+        defaultViewOrder: "ModifiedDate",
+        defaultViewPriorityVisibility: false,
+        defaultViewPriorityGrouping: false,
+      },
+    ],
+    hidden: [
+      {
+        name: "Archived",
+        link: true,
+        defaultViewMode: "Small Cards",
+        defaultViewOrder: "ModifiedDate",
+        defaultViewPriorityVisibility: false,
+        defaultViewPriorityGrouping: false,
+      },
+      {
+        name: "Cancelled",
+        link: true,
+        defaultViewMode: "Detailed Cards",
+        defaultViewOrder: "ModifiedDate",
+        defaultViewPriorityVisibility: false,
+        defaultViewPriorityGrouping: false,
+      },
+    ],
+  },
+  stateless: {
+    name: "",
+    defaultViewMode: "List",
+    defaultViewOrder: "ModifiedDate",
+    defaultViewPriorityVisibility: true,
+    defaultViewPriorityGrouping: true,
+  },
+  defaultState: "Idea",
 
-	priorities: [
-		{
-			...DEFAULT_PRIORITY_SETTINGS_0_3_0,
-			name: 'High',
-		},
-		{
-			...DEFAULT_PRIORITY_SETTINGS_0_3_0,
-			name: 'Low',
-		},
-	],
-}
+  priorities: [
+    {
+      ...DEFAULT_PRIORITY_SETTINGS_0_3_0,
+      name: "High",
+    },
+    {
+      ...DEFAULT_PRIORITY_SETTINGS_0_3_0,
+      name: "Low",
+    },
+  ],
+};


### PR DESCRIPTION
This PR adds a new "Browser Mode" setting that allows users to switch between the default **Folder-based** navigation and a new **Tag-based** navigation.

**Changes:**
1.  **Settings:** Added a `browserMode` toggle in Settings (Folder vs Tag).
2.  **Logic:** Created `src/logic/tag-processes.ts` to handle file fetching based on tags using the Metadata Cache.
3.  **UI:** Updated `CardBrowser` to handle tag paths and added logic to "Virtualize" tags as folders for navigation.
4.  **UX:** Hidden context menu options (Rename/Delete folder) when in Tag mode, as they don't apply to tags.

**How to test:**
1.  Go to Settings > Project Browser.
2.  Switch "Browser Mode" to **Tags**.
3.  Reload the view.
4.  The browser will now show top-level tags as folders. Clicking them filters notes by that tag.


> Your plugin has been a huge help, but I recently switched to a tag-based workflow, and Project Browser wasn’t as useful for tag navigation. So I tried making some changes myself. It’s my first time, so the code might be a bit amateur, but it works! I’d love to see this feature added to the plugin and thank you again for creating it. ❤️