### PR TITLE
Fix page menu touch guards

### DIFF
--- a/src/components/project-pages-fab/project-pages-fab.scss
+++ b/src/components/project-pages-fab/project-pages-fab.scss
@@ -27,6 +27,7 @@
         overflow-y: auto;
         padding-top: 12px;
         padding-bottom: 12px;
+        pointer-events: auto;
         scrollbar-width: none;
         -ms-overflow-style: none;
 
@@ -102,9 +103,11 @@
         padding: 8px 12px;
         border-radius: 8px;
         box-shadow: 0 5px 20px rgba(0, 0, 0, 0.2);
-        white-space: nowrap;
+        white-space: normal;
+        overflow-wrap: anywhere;
         overflow: hidden;
-        text-overflow: ellipsis;
+        text-align: right;
+        line-height: 1.25;
         font-size: 0.9em;
 
         .ddc_pb_project-page-menu__file-button-tags {

--- a/src/components/project-pages-fab/project-pages-fab.tsx
+++ b/src/components/project-pages-fab/project-pages-fab.tsx
@@ -33,6 +33,12 @@ function isPathInFolder(filePath: string, parentPath: string): boolean {
     return fileParentPath === parentPath;
 }
 
+function stopPageListGesturePropagation(event: React.SyntheticEvent) {
+    // The page list floats over the editor; even transparent gaps must own gestures
+    // so attempted menu scrolls cannot drag or interact with the underlying note.
+    event.stopPropagation();
+}
+
 export const ProjectPagesFAB = (props: ProjectPagesFABProps) => {
     const [menuIsOpen, setMenuIsOpen] = React.useState(!!props.initialMenuOpen);
     const [refreshTrigger, setRefreshTrigger] = React.useState(0);
@@ -186,6 +192,10 @@ export const ProjectPagesFAB = (props: ProjectPagesFABProps) => {
                     className="ddc_pb_project-pages-fab__page-list-scroll"
                     ref={pageListScrollRef}
                     onScroll={handlePageListScroll}
+                    onPointerDown={stopPageListGesturePropagation}
+                    onPointerMove={stopPageListGesturePropagation}
+                    onPointerUp={stopPageListGesturePropagation}
+                    onWheel={stopPageListGesturePropagation}
                 >
                     <div
                         ref={pageListInnerRef}


### PR DESCRIPTION
## Summary

- Captured gestures on the transparent page menu scroll area so taps and attempted scrolls between buttons no longer reach the underlying note.
- Let long page names wrap inside FAB page buttons while preserving the maximum button width and right-aligned label style.

## ClickUp

- [Prevent passing through touches between page buttons](https://app.clickup.com/t/86d3cawaw) - `86d3cawaw`
- [Capture attempted page menu scrolls even if not scrollable to prevent confusion](https://app.clickup.com/t/86d3caw81) - `86d3caw81`
- [Don't clip page names in the page menu](https://app.clickup.com/t/86d310rbr) - `86d310rbr`

## Test plan

- [x] `npm run test:unit -- project-pages-fab --coverage=false`
- [x] `npm exec eslint -- src/components/project-pages-fab/project-pages-fab.tsx`
- [x] `npm run build`
- [ ] `npm run lint` (project-wide lint currently fails on existing files outside this change)
- [ ] `npm run test:unit` (project-wide unit suite currently fails in `src/logic/file-access-processes.test.ts` outside this change)

Made with [Cursor](https://cursor.com)