### PR TITLE
Split state menu visibility settings

### DIFF
--- a/src/commands/cycle-state.ts
+++ b/src/commands/cycle-state.ts
@@ -4,7 +4,7 @@ import { setFileState } from "src/logic/frontmatter-processes";
 import { offsetState } from "src/logic/offset-state";
 import { getStateSettingsForFile } from "src/logic/project-page-states";
 import { getGlobals } from "src/logic/stores";
-import { openStateMenuIfClosed, returnStateMenuAfterDelay } from "src/logic/toggle-state-menu";
+import { getStateMenuSurfaceForFile, openStateMenuIfClosed, returnStateMenuAfterDelay } from "src/logic/toggle-state-menu";
 
 ////////
 ////////
@@ -19,12 +19,7 @@ export async function registerCycleStateCommands() {
         editorCallback: (editor: Editor) => {
             const file = plugin.app.workspace.getActiveFile();
             if(!file) return;
-            const wasOpen = openStateMenuIfClosed();
-            const delayMs = wasOpen ? 0 : 300; // This timing should match the open time of the menu
-            window.setTimeout(() => {
-                void cycleFileState(file, 1);
-            }, delayMs);
-            returnStateMenuAfterDelay();
+            void cycleFileStateWithMenu(file, 1);
         }
 	});
 
@@ -35,14 +30,19 @@ export async function registerCycleStateCommands() {
         editorCallback: (editor: Editor) => {
             const file = plugin.app.workspace.getActiveFile();
             if(!file) return;
-            const wasOpen = openStateMenuIfClosed();
-            const delayMs = wasOpen ? 0 : 300; // This timing should match the open time of the menu
-            window.setTimeout(() => {
-                void cycleFileState(file, -1);
-            }, delayMs);
-            returnStateMenuAfterDelay();
+            void cycleFileStateWithMenu(file, -1);
         }
 	});
+
+    async function cycleFileStateWithMenu(file: import("obsidian").TFile, offset: number) {
+        const surface = await getStateMenuSurfaceForFile(file);
+        const wasOpen = openStateMenuIfClosed(surface);
+        const delayMs = wasOpen ? 0 : 300; // This timing should match the open time of the menu
+        window.setTimeout(() => {
+            void cycleFileState(file, offset);
+        }, delayMs);
+        returnStateMenuAfterDelay(surface);
+    }
 
     async function cycleFileState(file: import("obsidian").TFile, offset: number) {
         const scopedSettings = await getStateSettingsForFile(file);

--- a/src/components/card-browser/card-browser.tsx
+++ b/src/components/card-browser/card-browser.tsx
@@ -34,7 +34,8 @@ export const CardBrowserContext = React.createContext<{
 });
 
 export interface CardBrowserHandlers {
-    rerender: Function,
+    rerender: () => void,
+    getCurrentFolderIsProject: () => boolean,
 }
 // export const cardBrowserHandlers = atom<CardBrowserHandlers>()
 
@@ -139,10 +140,6 @@ export const CardBrowser = (props: CardBrowserProps) => {
     // on mount
     React.useEffect( () => {
         if(!plugin) return;
-        
-        props.passBackHandlers({
-            rerender,
-        })
         plugin.addGlobalFileDependant(`card-browser_${viewInstanceId}`, rerender);
 
         if(plugin && browserRef.current) {
@@ -153,6 +150,13 @@ export const CardBrowser = (props: CardBrowserProps) => {
         }
         
     },[])
+
+    React.useEffect(() => {
+        props.passBackHandlers({
+            rerender,
+            getCurrentFolderIsProject: () => currentFolderIsProject,
+        });
+    }, [currentFolderIsProject]);
 
     const getCurFolder = (): TFolder => {
         const curFolder = v.getFolderByPath(props.getViewStates().state.path) || v.getRoot();

--- a/src/components/project-pages-fab/project-pages-fab.scss
+++ b/src/components/project-pages-fab/project-pages-fab.scss
@@ -27,6 +27,7 @@
         overflow-y: auto;
         padding-top: 12px;
         padding-bottom: 12px;
+        pointer-events: auto;
         scrollbar-width: none;
         -ms-overflow-style: none;
 
@@ -102,9 +103,11 @@
         padding: 8px 12px;
         border-radius: 8px;
         box-shadow: 0 5px 20px rgba(0, 0, 0, 0.2);
-        white-space: nowrap;
+        white-space: normal;
+        overflow-wrap: anywhere;
         overflow: hidden;
-        text-overflow: ellipsis;
+        text-align: right;
+        line-height: 1.25;
         font-size: 0.9em;
 
         .ddc_pb_project-page-menu__file-button-tags {

--- a/src/components/project-pages-fab/project-pages-fab.tsx
+++ b/src/components/project-pages-fab/project-pages-fab.tsx
@@ -33,6 +33,12 @@ function isPathInFolder(filePath: string, parentPath: string): boolean {
     return fileParentPath === parentPath;
 }
 
+function stopPageListGesturePropagation(event: React.SyntheticEvent) {
+    // The page list floats over the editor; even transparent gaps must own gestures
+    // so attempted menu scrolls cannot drag or interact with the underlying note.
+    event.stopPropagation();
+}
+
 export const ProjectPagesFAB = (props: ProjectPagesFABProps) => {
     const [menuIsOpen, setMenuIsOpen] = React.useState(!!props.initialMenuOpen);
     const [refreshTrigger, setRefreshTrigger] = React.useState(0);
@@ -186,6 +192,10 @@ export const ProjectPagesFAB = (props: ProjectPagesFABProps) => {
                     className="ddc_pb_project-pages-fab__page-list-scroll"
                     ref={pageListScrollRef}
                     onScroll={handlePageListScroll}
+                    onPointerDown={stopPageListGesturePropagation}
+                    onPointerMove={stopPageListGesturePropagation}
+                    onPointerUp={stopPageListGesturePropagation}
+                    onWheel={stopPageListGesturePropagation}
                 >
                     <div
                         ref={pageListInnerRef}

--- a/src/components/state-menu/project-folder-state-menu.tsx
+++ b/src/components/state-menu/project-folder-state-menu.tsx
@@ -37,6 +37,7 @@ export const ProjectFolderStateMenu = (props: ProjectFolderStateMenuProps) => {
             currentStateSettings={currentStateSettings}
             visibleStates={plugin.settings.states.visible}
             hiddenStates={plugin.settings.states.hidden}
+            visibilitySurface="noteAndProject"
             onSetState={setProjectFolderState}
         />
     );

--- a/src/components/state-menu/project-page-state-menu.tsx
+++ b/src/components/state-menu/project-page-state-menu.tsx
@@ -42,6 +42,7 @@ export const ProjectPageStateMenu = (props: ProjectPageStateMenuProps) => {
             currentStateSettings={stateSettings}
             visibleStates={plugin.settings.projectPageStates.visible}
             hiddenStates={plugin.settings.projectPageStates.hidden}
+            visibilitySurface="page"
             onSetState={setStateAndUpdateMenu}
         />
     );

--- a/src/components/state-menu/state-menu-shell.tsx
+++ b/src/components/state-menu/state-menu-shell.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import classnames from 'classnames';
 import { useAtomValue } from 'jotai';
-import { stateMenuAtom } from 'src/logic/stores';
+import { getStateMenuSurfaceVisibility, stateMenuAtom, StateMenuSurface } from 'src/logic/stores';
 import { StateSettings } from 'src/types/types-map';
 import { sanitizeInternalLinkName } from 'src/utils/string-processes';
 
@@ -9,21 +9,23 @@ interface StateMenuShellProps {
     currentStateSettings: StateSettings | null;
     visibleStates: StateSettings[];
     hiddenStates: StateSettings[];
+    visibilitySurface: StateMenuSurface;
     onSetState: (stateSettings: StateSettings | null) => Promise<boolean>;
 }
 
 export const StateMenuShell = (props: StateMenuShellProps) => {
     const stateMenuSettings = useAtomValue(stateMenuAtom);
+    const stateMenuIsVisible = getStateMenuSurfaceVisibility(stateMenuSettings, props.visibilitySurface);
     const [menuIsActive, setMenuIsActive] = React.useState(false);
     const showHighlightRef = React.useRef<boolean>(false);
     const stateMenuRef = React.useRef<HTMLDivElement>(null);
     const stateMenuContentRef = React.useRef<HTMLDivElement>(null);
     const resizeObserverRef = React.useRef<ResizeObserver | null>(null);
 
-    const stateMenuSettingsRef = React.useRef(stateMenuSettings);
+    const stateMenuIsVisibleRef = React.useRef(stateMenuIsVisible);
     React.useEffect(() => {
-        stateMenuSettingsRef.current = stateMenuSettings;
-    }, [stateMenuSettings]);
+        stateMenuIsVisibleRef.current = stateMenuIsVisible;
+    }, [stateMenuIsVisible]);
 
     const displayState = props.currentStateSettings?.name || 'Set State';
 
@@ -45,7 +47,7 @@ export const StateMenuShell = (props: StateMenuShellProps) => {
 
     React.useEffect(() => {
         setHeight();
-    }, [stateMenuSettings, menuIsActive]);
+    }, [stateMenuIsVisible, menuIsActive]);
 
     React.useEffect(() => {
         showHighlightRef.current = false;
@@ -124,7 +126,7 @@ export const StateMenuShell = (props: StateMenuShellProps) => {
     }
 
     function setHeight() {
-        if (stateMenuSettingsRef.current.visible) {
+        if (stateMenuIsVisibleRef.current) {
             setVisibleHeight();
         } else {
             setHiddenHeight();

--- a/src/components/state-menu/state-menu-shell.tsx
+++ b/src/components/state-menu/state-menu-shell.tsx
@@ -28,6 +28,28 @@ export const StateMenuShell = (props: StateMenuShellProps) => {
     }, [stateMenuIsVisible]);
 
     const displayState = props.currentStateSettings?.name || 'Set State';
+    // Hide the compact closed button when this surface is toggled off; height collapse alone
+    // leaves the button visible in card-browser layouts that do not clip overflow.
+    const closedMenuButton = stateMenuIsVisible && !menuIsActive && (
+        <button
+            className={classnames([
+                'ddc_pb_state-btn',
+                'ddc_pb_in-closed-menu',
+                showHighlightRef.current && 'ddc_pb_has-return-transition',
+            ])}
+            onClick={() => {
+                setMenuIsActive(true);
+            }}
+        >
+            {displayState}
+        </button>
+    );
+
+    React.useEffect(() => {
+        if (!stateMenuIsVisible) {
+            setMenuIsActive(false);
+        }
+    }, [stateMenuIsVisible]);
 
     React.useEffect(() => {
         function handleClickOutside(event: PointerEvent) {
@@ -62,22 +84,9 @@ export const StateMenuShell = (props: StateMenuShellProps) => {
                 className='ddc_pb_state-menu-content'
                 ref={stateMenuContentRef}
             >
-                {!menuIsActive && (
-                    <button
-                        className={classnames([
-                            'ddc_pb_state-btn',
-                            'ddc_pb_in-closed-menu',
-                            showHighlightRef.current && 'ddc_pb_has-return-transition',
-                        ])}
-                        onClick={() => {
-                            setMenuIsActive(true);
-                        }}
-                    >
-                        {displayState}
-                    </button>
-                )}
+                {closedMenuButton}
 
-                {menuIsActive && (
+                {menuIsActive && stateMenuIsVisible && (
                     <>
                         <div className='ddc_pb_visible-state-btns'>
                             {props.visibleStates.map((visibleStateSettings) => (

--- a/src/components/state-menu/state-menu.scss
+++ b/src/components/state-menu/state-menu.scss
@@ -2,6 +2,7 @@
 
 .ddc_pb_state-menu {
     height: 0;
+    overflow: hidden;
     transition: height 0.3s ease-in-out;
 }   
 

--- a/src/components/state-menu/state-menu.tsx
+++ b/src/components/state-menu/state-menu.tsx
@@ -75,6 +75,7 @@ const StandardStateMenu = (props: StateMenuProps) => {
             currentStateSettings={stateSettings}
             visibleStates={plugin.settings.states.visible}
             hiddenStates={plugin.settings.states.hidden}
+            visibilitySurface="noteAndProject"
             onSetState={setStateAndUpdateMenu}
         />
     );

--- a/src/logic/stores.test.ts
+++ b/src/logic/stores.test.ts
@@ -12,7 +12,11 @@ import {
 
 describe('stores', () => {
   const mockPlugin = {
-    settings: { showStateMenu: true },
+    settings: {
+      showStateMenu: true,
+      showNoteAndProjectStateMenu: true,
+      showPageStateMenu: true,
+    },
     saveSettings: jest.fn(),
   };
 
@@ -31,20 +35,41 @@ describe('stores', () => {
 
   describe('stateMenuAtom', () => {
     test('setStateMenuSettings and getStateMenuSettings round-trip', () => {
-      setStateMenuSettings({ visible: true });
-      expect(getStateMenuSettings()).toEqual({ visible: true });
-      setStateMenuSettings({ visible: false });
-      expect(getStateMenuSettings()).toEqual({ visible: false });
+      setStateMenuSettings({ noteAndProjectVisible: true, pageVisible: false });
+      expect(getStateMenuSettings()).toEqual({ noteAndProjectVisible: true, pageVisible: false });
+      setStateMenuSettings({ noteAndProjectVisible: false, pageVisible: true });
+      expect(getStateMenuSettings()).toEqual({ noteAndProjectVisible: false, pageVisible: true });
     });
   });
 
   describe('initStateMenuSettings', () => {
-    test('sets state menu visible from plugin.settings.showStateMenu', () => {
-      setStateMenuSettings({ visible: true });
+    test('sets state menu visibility from split plugin settings', () => {
+      setStateMenuSettings({ noteAndProjectVisible: true, pageVisible: true });
+      const plugin = {
+        settings: {
+          showStateMenu: true,
+          showNoteAndProjectStateMenu: false,
+          showPageStateMenu: true,
+        },
+        saveSettings: jest.fn(),
+      };
+      setGlobals({ plugin: plugin as unknown as ReturnType<typeof getGlobals>['plugin'] });
+      initStateMenuSettings();
+      expect(getStateMenuSettings()).toEqual({
+        noteAndProjectVisible: false,
+        pageVisible: true,
+      });
+    });
+
+    test('falls back to legacy showStateMenu when split settings are absent', () => {
+      setStateMenuSettings({ noteAndProjectVisible: true, pageVisible: true });
       const plugin = { settings: { showStateMenu: false }, saveSettings: jest.fn() };
       setGlobals({ plugin: plugin as unknown as ReturnType<typeof getGlobals>['plugin'] });
       initStateMenuSettings();
-      expect(getStateMenuSettings().visible).toBe(false);
+      expect(getStateMenuSettings()).toEqual({
+        noteAndProjectVisible: false,
+        pageVisible: false,
+      });
     });
   });
 

--- a/src/logic/stores.ts
+++ b/src/logic/stores.ts
@@ -33,19 +33,24 @@ export function getGlobals(): StaticGlobals {
 
 export const globalStore = createStore();
 
-interface StateMenuSettings {
-	visible: boolean,
+export type StateMenuSurface = 'noteAndProject' | 'page';
+
+export interface StateMenuSettings {
+	noteAndProjectVisible: boolean,
+	pageVisible: boolean,
 };
 const defaultStateMenuSettings: StateMenuSettings = {
-	visible: true,
+	noteAndProjectVisible: true,
+	pageVisible: true,
 };
 export const stateMenuAtom = atom<StateMenuSettings>(defaultStateMenuSettings)
 export function initStateMenuSettings() {
 	const {plugin} = getGlobals();
 	const store = getDefaultStore();
 	const curStateMenuSettings = store.get(stateMenuAtom);
-	const newStateMenuSettings = JSON.parse(JSON.stringify(curStateMenuSettings));
-	newStateMenuSettings.visible = plugin.settings.showStateMenu;
+	const newStateMenuSettings: StateMenuSettings = { ...curStateMenuSettings };
+	newStateMenuSettings.noteAndProjectVisible = plugin.settings.showNoteAndProjectStateMenu ?? plugin.settings.showStateMenu;
+	newStateMenuSettings.pageVisible = plugin.settings.showPageStateMenu ?? plugin.settings.showStateMenu;
 	store.set(stateMenuAtom, newStateMenuSettings);
 }
 export function setStateMenuSettings(stateMenuSettings: StateMenuSettings): void {
@@ -55,6 +60,20 @@ export function setStateMenuSettings(stateMenuSettings: StateMenuSettings): void
 export function getStateMenuSettings(): StateMenuSettings {
 	const store = getDefaultStore();
 	return store.get(stateMenuAtom);
+}
+export function getStateMenuSurfaceVisibility(stateMenuSettings: StateMenuSettings, surface: StateMenuSurface): boolean {
+	return surface === 'page' ? stateMenuSettings.pageVisible : stateMenuSettings.noteAndProjectVisible;
+}
+export function setStateMenuSurfaceVisibility(
+	stateMenuSettings: StateMenuSettings,
+	surface: StateMenuSurface,
+	visible: boolean,
+): void {
+	if (surface === 'page') {
+		stateMenuSettings.pageVisible = visible;
+		return;
+	}
+	stateMenuSettings.noteAndProjectVisible = visible;
 }
 
 //////////

--- a/src/logic/stores.ts
+++ b/src/logic/stores.ts
@@ -44,22 +44,20 @@ const defaultStateMenuSettings: StateMenuSettings = {
 	pageVisible: true,
 };
 export const stateMenuAtom = atom<StateMenuSettings>(defaultStateMenuSettings)
+// Card browser React trees use JotaiProvider with globalStore; keep state menu reads/writes on that store.
 export function initStateMenuSettings() {
 	const {plugin} = getGlobals();
-	const store = getDefaultStore();
-	const curStateMenuSettings = store.get(stateMenuAtom);
+	const curStateMenuSettings = globalStore.get(stateMenuAtom);
 	const newStateMenuSettings: StateMenuSettings = { ...curStateMenuSettings };
 	newStateMenuSettings.noteAndProjectVisible = plugin.settings.showNoteAndProjectStateMenu ?? plugin.settings.showStateMenu;
 	newStateMenuSettings.pageVisible = plugin.settings.showPageStateMenu ?? plugin.settings.showStateMenu;
-	store.set(stateMenuAtom, newStateMenuSettings);
+	globalStore.set(stateMenuAtom, newStateMenuSettings);
 }
 export function setStateMenuSettings(stateMenuSettings: StateMenuSettings): void {
-	const store = getDefaultStore();
-	store.set(stateMenuAtom, stateMenuSettings);
+	globalStore.set(stateMenuAtom, stateMenuSettings);
 }
 export function getStateMenuSettings(): StateMenuSettings {
-	const store = getDefaultStore();
-	return store.get(stateMenuAtom);
+	return globalStore.get(stateMenuAtom);
 }
 export function getStateMenuSurfaceVisibility(stateMenuSettings: StateMenuSettings, surface: StateMenuSurface): boolean {
 	return surface === 'page' ? stateMenuSettings.pageVisible : stateMenuSettings.noteAndProjectVisible;

--- a/src/logic/toggle-state-menu.test.ts
+++ b/src/logic/toggle-state-menu.test.ts
@@ -1,17 +1,24 @@
 import { describe, expect, test, jest, beforeEach, afterEach } from '@jest/globals';
 import { setGlobals, setStateMenuSettings, getStateMenuSettings } from './stores';
-import { toggleStateMenu, openStateMenuIfClosed, returnStateMenuAfterDelay } from './toggle-state-menu';
+import { toggleStateMenuSurface, openStateMenuIfClosed, returnStateMenuAfterDelay } from './toggle-state-menu';
 
 describe('toggle-state-menu', () => {
   const mockSaveSettings = jest.fn();
   const mockPlugin = {
-    settings: { showStateMenu: true },
+    settings: {
+      showStateMenu: true,
+      showNoteAndProjectStateMenu: true,
+      showPageStateMenu: true,
+    },
     saveSettings: mockSaveSettings,
   };
 
   beforeEach(() => {
     setGlobals({ plugin: mockPlugin as unknown as ReturnType<typeof import('./stores').getGlobals>['plugin'] });
-    setStateMenuSettings({ visible: true });
+    setStateMenuSettings({ noteAndProjectVisible: true, pageVisible: true });
+    mockPlugin.settings.showStateMenu = true;
+    mockPlugin.settings.showNoteAndProjectStateMenu = true;
+    mockPlugin.settings.showPageStateMenu = true;
     mockSaveSettings.mockClear();
     jest.useFakeTimers();
   });
@@ -21,41 +28,54 @@ describe('toggle-state-menu', () => {
   });
 
   describe('toggleStateMenu', () => {
-    test('toggles visible and updates plugin.settings.showStateMenu and saveSettings', () => {
-      expect(getStateMenuSettings().visible).toBe(true);
-      toggleStateMenu();
-      expect(getStateMenuSettings().visible).toBe(false);
+    test('toggles note and project visibility and keeps legacy showStateMenu in sync', () => {
+      expect(getStateMenuSettings().noteAndProjectVisible).toBe(true);
+      toggleStateMenuSurface('noteAndProject');
+      expect(getStateMenuSettings().noteAndProjectVisible).toBe(false);
       expect(mockPlugin.settings.showStateMenu).toBe(false);
+      expect(mockPlugin.settings.showNoteAndProjectStateMenu).toBe(false);
       expect(mockSaveSettings).toHaveBeenCalled();
 
-      toggleStateMenu();
-      expect(getStateMenuSettings().visible).toBe(true);
+      toggleStateMenuSurface('noteAndProject');
+      expect(getStateMenuSettings().noteAndProjectVisible).toBe(true);
       expect(mockPlugin.settings.showStateMenu).toBe(true);
+      expect(mockPlugin.settings.showNoteAndProjectStateMenu).toBe(true);
       expect(mockSaveSettings).toHaveBeenCalledTimes(2);
+    });
+
+    test('toggles page visibility without changing note and project visibility', () => {
+      toggleStateMenuSurface('page');
+      expect(getStateMenuSettings()).toEqual({
+        noteAndProjectVisible: true,
+        pageVisible: false,
+      });
+      expect(mockPlugin.settings.showPageStateMenu).toBe(false);
+      expect(mockPlugin.settings.showNoteAndProjectStateMenu).toBe(true);
     });
   });
 
   describe('openStateMenuIfClosed', () => {
     test('returns true when menu already visible', () => {
-      setStateMenuSettings({ visible: true });
+      setStateMenuSettings({ noteAndProjectVisible: true, pageVisible: true });
       expect(openStateMenuIfClosed()).toBe(true);
     });
 
     test('opens menu and returns false when menu was closed', () => {
-      setStateMenuSettings({ visible: false });
-      expect(openStateMenuIfClosed()).toBe(false);
-      expect(getStateMenuSettings().visible).toBe(true);
+      setStateMenuSettings({ noteAndProjectVisible: true, pageVisible: false });
+      expect(openStateMenuIfClosed('page')).toBe(false);
+      expect(getStateMenuSettings().pageVisible).toBe(true);
     });
   });
 
   describe('returnStateMenuAfterDelay', () => {
     test('closes menu after delay when it was opened by openStateMenuIfClosed', () => {
-      setStateMenuSettings({ visible: false });
-      openStateMenuIfClosed();
-      expect(getStateMenuSettings().visible).toBe(true);
-      returnStateMenuAfterDelay();
+      setStateMenuSettings({ noteAndProjectVisible: true, pageVisible: false });
+      openStateMenuIfClosed('page');
+      expect(getStateMenuSettings().pageVisible).toBe(true);
+      returnStateMenuAfterDelay('page');
       jest.advanceTimersByTime(1000);
-      expect(getStateMenuSettings().visible).toBe(false);
+      expect(getStateMenuSettings().pageVisible).toBe(false);
+      expect(getStateMenuSettings().noteAndProjectVisible).toBe(true);
     });
   });
 });

--- a/src/logic/toggle-state-menu.ts
+++ b/src/logic/toggle-state-menu.ts
@@ -1,42 +1,74 @@
-import { getGlobals, getStateMenuSettings, setStateMenuSettings } from "./stores";
+import { TFile } from "obsidian";
+import { getFileStateScope } from "src/logic/project-page-states";
+import {
+    getGlobals,
+    getStateMenuSettings,
+    getStateMenuSurfaceVisibility,
+    setStateMenuSettings,
+    setStateMenuSurfaceVisibility,
+    StateMenuSurface,
+} from "./stores";
 
 //////////////////
 //////////////////
 
-export function toggleStateMenu() {
+export async function toggleStateMenu() {
+    const {plugin} = getGlobals();
+    const activeFile = plugin.app.workspace.getActiveFile();
+    const surface = activeFile ? await getStateMenuSurfaceForFile(activeFile) : 'noteAndProject';
+    toggleStateMenuSurface(surface);
+}
+
+export async function toggleStateMenuForFile(file: TFile) {
+    const surface = await getStateMenuSurfaceForFile(file);
+    toggleStateMenuSurface(surface);
+}
+
+export function toggleStateMenuSurface(surface: StateMenuSurface) {
     const {plugin} = getGlobals();
     const stateMenuSettings = getStateMenuSettings();
-    const newStateMenuSettings = JSON.parse(JSON.stringify(stateMenuSettings));
-    newStateMenuSettings.visible = !newStateMenuSettings.visible;
+    const newStateMenuSettings = { ...stateMenuSettings };
+    const nextVisible = !getStateMenuSurfaceVisibility(stateMenuSettings, surface);
+    setStateMenuSurfaceVisibility(newStateMenuSettings, surface, nextVisible);
     setStateMenuSettings(newStateMenuSettings);
-    
-    plugin.settings.showStateMenu = newStateMenuSettings.visible;
+
+    if (surface === 'page') {
+        plugin.settings.showPageStateMenu = nextVisible;
+    } else {
+        plugin.settings.showNoteAndProjectStateMenu = nextVisible;
+        plugin.settings.showStateMenu = nextVisible;
+    }
     void plugin.saveSettings();
+}
+
+export async function getStateMenuSurfaceForFile(file: TFile): Promise<StateMenuSurface> {
+    const stateScope = await getFileStateScope(file);
+    return stateScope === 'projectPage' ? 'page' : 'noteAndProject';
 }
 
 //////////////////
 
 let cycleStateTimeout: NodeJS.Timeout | null = null;
-let openedByFunction = false;
+let openedSurfaceByFunction: StateMenuSurface | null = null;
 
-export function openStateMenuIfClosed(): boolean {
+export function openStateMenuIfClosed(surface: StateMenuSurface = 'noteAndProject'): boolean {
     const curStateMenuSettings = getStateMenuSettings();
-    if(curStateMenuSettings.visible) return true;
-    const newStateMenuSettings = JSON.parse(JSON.stringify(curStateMenuSettings));
-    newStateMenuSettings.visible = true;
+    if(getStateMenuSurfaceVisibility(curStateMenuSettings, surface)) return true;
+    const newStateMenuSettings = { ...curStateMenuSettings };
+    setStateMenuSurfaceVisibility(newStateMenuSettings, surface, true);
     setStateMenuSettings(newStateMenuSettings);
-    openedByFunction = true;
+    openedSurfaceByFunction = surface;
     return false;
 }
 
-export function returnStateMenuAfterDelay() {
+export function returnStateMenuAfterDelay(surface: StateMenuSurface = 'noteAndProject') {
     if(cycleStateTimeout) window.clearTimeout(cycleStateTimeout);
     cycleStateTimeout = window.setTimeout(() => {
-        if(!openedByFunction) return;
-        openedByFunction = false;
+        if(openedSurfaceByFunction !== surface) return;
+        openedSurfaceByFunction = null;
         const curStateMenuSettings = getStateMenuSettings();
-        const newStateMenuSettings = JSON.parse(JSON.stringify(curStateMenuSettings));
-        newStateMenuSettings.visible = false;
+        const newStateMenuSettings = { ...curStateMenuSettings };
+        setStateMenuSurfaceVisibility(newStateMenuSettings, surface, false);
         setStateMenuSettings(newStateMenuSettings);
     }, 1000);
 }

--- a/src/tabs/settings-tab/settings-tab.ts
+++ b/src/tabs/settings-tab/settings-tab.ts
@@ -280,7 +280,7 @@ function insertStateSettings(containerEl: HTMLElement, refresh: () => void) {
 
 	new Setting(contentEl)
 		.setClass("ddc_pb_setting")
-		.setName("Show note and project states")
+		.setName("Show note and project state menu")
 		.setDesc(
 			"Show the state menu for regular notes and project root views. This can also be toggled from the view menu.",
 		)
@@ -368,7 +368,7 @@ function insertProjectPageStateSettings(
 
 	new Setting(contentEl)
 		.setClass("ddc_pb_setting")
-		.setName("Show page states")
+		.setName("Show page state menu")
 		.setDesc(
 			"Show the page state menu for markdown pages inside project folders. This can also be toggled from the view menu.",
 		)

--- a/src/tabs/settings-tab/settings-tab.ts
+++ b/src/tabs/settings-tab/settings-tab.ts
@@ -6,7 +6,12 @@ import { PluginSettingTab, Setting } from "obsidian";
 import MyPlugin from "src/main";
 import { ConfirmationModal } from "src/modals/confirmation-modal/confirmation-modal";
 import { folderPathSanitize } from "src/utils/string-processes";
-import { getGlobals } from "src/logic/stores";
+import {
+	getGlobals,
+	getStateMenuSettings,
+	setStateMenuSettings,
+	setStateMenuSurfaceVisibility,
+} from "src/logic/stores";
 import { StateSettings } from "src/types/types-map";
 import { showWelcomeTips } from "src/notices/onboarding-notices";
 import { showRecentChanges } from "src/notices/version-notices";
@@ -266,12 +271,31 @@ function insertStateSettings(containerEl: HTMLElement, refresh: () => void) {
 
 	new Setting(sectionEl)
 		.setClass("ddc_pb_controls-header")
-		.setName("File & project states")
+		.setName("Note & project states")
 		.setDesc(
-			"This is the list of categories that Project Browser will help assign projects and group by in the Browser view. Add new project states and drag them to reorder or delete.",
+			"This is the list of categories that Project Browser will help assign notes and projects, and group by in the Browser view. Add new states and drag them to reorder or delete.",
 		);
 
 	const contentEl = sectionEl.createDiv("ddc_pb_controls-content");
+
+	new Setting(contentEl)
+		.setClass("ddc_pb_setting")
+		.setName("Show note and project states")
+		.setDesc(
+			"Show the state menu for regular notes and project root views. This can also be toggled from the view menu.",
+		)
+		.addToggle((toggle) => {
+			toggle.setValue(plugin.settings.showNoteAndProjectStateMenu);
+			toggle.onChange(async (value) => {
+				plugin.settings.showNoteAndProjectStateMenu = value;
+				plugin.settings.showStateMenu = value;
+				const stateMenuSettings = { ...getStateMenuSettings() };
+				setStateMenuSurfaceVisibility(stateMenuSettings, 'noteAndProject', value);
+				setStateMenuSettings(stateMenuSettings);
+				await plugin.saveSettings();
+				refresh();
+			});
+		});
 
 	new Setting(contentEl)
 		.setClass("ddc_pb_setting")
@@ -341,6 +365,24 @@ function insertProjectPageStateSettings(
 		);
 
 	const contentEl = sectionEl.createDiv("ddc_pb_controls-content");
+
+	new Setting(contentEl)
+		.setClass("ddc_pb_setting")
+		.setName("Show page states")
+		.setDesc(
+			"Show the page state menu for markdown pages inside project folders. This can also be toggled from the view menu.",
+		)
+		.addToggle((toggle) => {
+			toggle.setValue(plugin.settings.showPageStateMenu);
+			toggle.onChange(async (value) => {
+				plugin.settings.showPageStateMenu = value;
+				const stateMenuSettings = { ...getStateMenuSettings() };
+				setStateMenuSurfaceVisibility(stateMenuSettings, 'page', value);
+				setStateMenuSettings(stateMenuSettings);
+				await plugin.saveSettings();
+				refresh();
+			});
+		});
 
 	new Setting(contentEl)
 		.setClass("ddc_pb_setting")
@@ -490,21 +532,6 @@ function insertNoteSettings(containerEl: HTMLElement, refresh: () => void) {
 		);
 
 	const contentEl = sectionEl.createDiv("ddc_pb_controls-content");
-
-	new Setting(contentEl)
-		.setClass("ddc_pb_setting")
-		.setName("Show state menu in notes")
-		.setDesc(
-			"This can be toggled any time through a command (Default shortcut: Cmd+Shift+S).",
-		)
-		.addToggle((toggle) => {
-			toggle.setValue(plugin.settings.showStateMenu);
-			toggle.onChange(async (value) => {
-				plugin.settings.showStateMenu = value;
-				await plugin.saveSettings();
-				refresh();
-			});
-		});
 
 	new Setting(contentEl)
 		.setClass("ddc_pb_setting")

--- a/src/types/plugin-settings-migrations.ts
+++ b/src/types/plugin-settings-migrations.ts
@@ -201,6 +201,8 @@ export function migrate_0_3_0_to_0_4_0(oldSettings: PluginSettings_0_3_0): Plugi
         projectPageStateless: { ...DEFAULT_PROJECT_PAGE_STATELESS_SETTINGS_0_4_0 },
         defaultProjectPageState: DEFAULT_PLUGIN_SETTINGS_0_4_0.defaultProjectPageState,
         loopProjectPageStatesWhenCycling: DEFAULT_PLUGIN_SETTINGS_0_4_0.loopProjectPageStatesWhenCycling,
+        showNoteAndProjectStateMenu: oldSettings.showStateMenu,
+        showPageStateMenu: oldSettings.showStateMenu,
         showRenamePopupOnNewPage: true,
     };
     return JSON.parse(JSON.stringify(newSettings));
@@ -227,6 +229,13 @@ function patch_0_4_0_settings(settings: PluginSettings_0_4_0): PluginSettings_0_
     }
     if (patched.loopProjectPageStatesWhenCycling === undefined) {
         patched.loopProjectPageStatesWhenCycling = DEFAULT_PLUGIN_SETTINGS_0_4_0.loopProjectPageStatesWhenCycling;
+    }
+    // Preserve shipped single-toggle behavior while letting new settings diverge after migration.
+    if (patched.showNoteAndProjectStateMenu === undefined) {
+        patched.showNoteAndProjectStateMenu = patched.showStateMenu;
+    }
+    if (patched.showPageStateMenu === undefined) {
+        patched.showPageStateMenu = patched.showStateMenu;
     }
 
     if (!patched.fileTypes) return patched;

--- a/src/types/plugin-settings_0_4_0.ts
+++ b/src/types/plugin-settings_0_4_0.ts
@@ -149,6 +149,10 @@ export const DEFAULT_PROJECT_PAGE_STATELESS_SETTINGS_0_4_0: StateSettings_0_3_0 
 
 export interface PluginSettings_0_4_0 extends PluginSettings_0_3_0 {
     settingsVersion: '0.4.0';
+    /** Shows note and project-root state menus. Migrated from the legacy single `showStateMenu` setting. */
+    showNoteAndProjectStateMenu: boolean;
+    /** Shows page state menus for markdown files inside project folders. Migrated from the legacy single `showStateMenu` setting. */
+    showPageStateMenu: boolean;
     fileTypes: FileTypeSettings_0_4_0;
     projectPageStates: StateCollectionSettings_0_4_0;
     projectPageStateless: StateSettings_0_3_0;
@@ -163,6 +167,8 @@ export interface PluginSettings_0_4_0 extends PluginSettings_0_3_0 {
 export const DEFAULT_PLUGIN_SETTINGS_0_4_0: PluginSettings_0_4_0 = {
     ...DEFAULT_PLUGIN_SETTINGS_0_3_0,
     settingsVersion: '0.4.0',
+    showNoteAndProjectStateMenu: DEFAULT_PLUGIN_SETTINGS_0_3_0.showStateMenu,
+    showPageStateMenu: DEFAULT_PLUGIN_SETTINGS_0_3_0.showStateMenu,
     fileTypes: { ...DEFAULT_FILE_TYPE_SETTINGS_0_4_0 },
     projectPageStates: {
         visible: [...DEFAULT_PROJECT_PAGE_STATE_SETTINGS_0_4_0.visible],

--- a/src/views/card-browser-view/card-browser-view.tsx
+++ b/src/views/card-browser-view/card-browser-view.tsx
@@ -1,4 +1,4 @@
-import { FileView, ItemView, MarkdownView, Notice, TFile, TFolder, View, ViewState, ViewStateResult, WorkspaceLeaf } from "obsidian";
+import { FileView, ItemView, MarkdownView, Menu, MenuItem, Notice, TFile, TFolder, View, ViewState, ViewStateResult, WorkspaceLeaf } from "obsidian";
 import * as React from "react";
 import { Root, createRoot } from "react-dom/client";
 import CardBrowser, { CardBrowserHandlers } from "src/components/card-browser/card-browser";
@@ -6,7 +6,8 @@ import { createContext } from 'react';
 import { isEmpty } from "src/utils/misc";
 import { ICON_PLUGIN } from "src/constants";
 import { Provider as JotaiProvider } from 'jotai';
-import { globalStore, getGlobals } from "src/logic/stores";
+import { globalStore, getGlobals, getStateMenuSettings, getStateMenuSurfaceVisibility } from "src/logic/stores";
+import { toggleStateMenuSurface } from "src/logic/toggle-state-menu";
 import { CARD_BROWSER_VIEW_TYPE } from './card-browser-view-constants';
 
 //////////
@@ -151,6 +152,19 @@ export class ProjectCardsView extends ItemView {
 
     getDisplayText() {
         return "Browse";
+    }
+
+    onPaneMenu(menu: Menu, source: string): void {
+        super.onPaneMenu(menu, source);
+        if (!this.cardBrowserHandlers?.getCurrentFolderIsProject()) return;
+
+        menu.addItem((item: MenuItem) => {
+            item.setTitle('Toggle state menu');
+            item.setChecked(getStateMenuSurfaceVisibility(getStateMenuSettings(), 'noteAndProject'));
+            item.onClick(() => toggleStateMenuSurface('noteAndProject'));
+            item.setSection('pane');
+            item.setIcon('file-check');
+        });
     }
 
     async onOpen() {

--- a/src/views/markdown-view-mods/markdown-view-mods.tsx
+++ b/src/views/markdown-view-mods/markdown-view-mods.tsx
@@ -4,7 +4,8 @@ import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { StateMenu } from 'src/components/state-menu/state-menu';
 import { ProjectPagesFAB } from 'src/components/project-pages-fab/project-pages-fab';
-import { getGlobals, getStateMenuSettings, getStateMenuSurfaceVisibility } from 'src/logic/stores';
+import { Provider as JotaiProvider } from 'jotai';
+import { getGlobals, globalStore, getStateMenuSettings, getStateMenuSurfaceVisibility } from 'src/logic/stores';
 import {
     getStateMenuSurfaceForFile,
     openStateMenuIfClosed,
@@ -121,7 +122,9 @@ function addStateHeader() {
     const stateMenuRoot = stateEl.__stateMenuRoot;
     if (stateMenuRoot) {
         stateMenuRoot.render(
-            <StateMenu file={activeFile}/>
+            <JotaiProvider store={globalStore}>
+                <StateMenu file={activeFile}/>
+            </JotaiProvider>
         );
     }
 }

--- a/src/views/markdown-view-mods/markdown-view-mods.tsx
+++ b/src/views/markdown-view-mods/markdown-view-mods.tsx
@@ -4,9 +4,13 @@ import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { StateMenu } from 'src/components/state-menu/state-menu';
 import { ProjectPagesFAB } from 'src/components/project-pages-fab/project-pages-fab';
-import { getGlobals, getStateMenuSettings } from 'src/logic/stores';
-import { toggleStateMenu } from 'src/logic/toggle-state-menu';
-import { openStateMenuIfClosed } from 'src/logic/toggle-state-menu';
+import { getGlobals, getStateMenuSettings, getStateMenuSurfaceVisibility } from 'src/logic/stores';
+import {
+    getStateMenuSurfaceForFile,
+    openStateMenuIfClosed,
+    toggleStateMenu,
+    toggleStateMenuForFile,
+} from 'src/logic/toggle-state-menu';
 import { openFileInSameLeaf, openNewPageAndSelectTitle } from 'src/logic/file-access-processes';
 import { createProject, createProjectFromNote, getFolderSettings } from 'src/utils/file-manipulation';
 import { CARD_BROWSER_VIEW_TYPE } from 'src/views/card-browser-view/card-browser-view-constants';
@@ -77,8 +81,11 @@ function addViewMenuOptions() {
         if(source !== 'more-options') return;
         menu.addItem((item: MenuItem) => {
             item.setTitle('Toggle state menu');
-            item.setChecked(getStateMenuSettings().visible);
-            item.onClick(toggleStateMenu);
+            item.setChecked(getStateMenuSurfaceVisibility(getStateMenuSettings(), 'noteAndProject'));
+            void getStateMenuSurfaceForFile(file).then((surface) => {
+                item.setChecked(getStateMenuSurfaceVisibility(getStateMenuSettings(), surface));
+            });
+            item.onClick(() => void toggleStateMenuForFile(file));
             item.setSection('pane');
             item.setIcon('file-check');
         });
@@ -88,7 +95,7 @@ function addViewMenuOptions() {
 function addActionButtons(view: View) {
     // TODO: Currently adding an extra button every time the view is clicked in.
     if (!(view instanceof MarkdownView)) return;
-    const element = view.addAction('file-stack', 'Toggle state menu', toggleStateMenu);
+    const element = view.addAction('file-stack', 'Toggle state menu', () => void toggleStateMenu());
 }
 
 function addStateHeader() {


### PR DESCRIPTION
## Summary

- Split state menu visibility into note/project and page settings so users can control those surfaces independently.
- Added project-root state menu toggling through the Project Browser view menu and kept legacy visibility settings migrated into both new controls.
- Updated temporary state-menu opening during state cycling to use the correct note/project or page surface.

## ClickUp

- [Add ability to toggle state menu to project roots & tweak settings](https://app.clickup.com/t/86d3cavnd) - `86d3cavnd`

## Test plan

- [x] `npm run test:unit -- stores toggle-state-menu plugin-settings-migrations --coverage=false`
- [x] `npm run build`
- [x] `git diff --check`
- [ ] `npm run lint` (project-wide lint currently fails on existing files outside this change)
- [ ] `npm run test:unit` (project-wide unit suite currently fails in `src/logic/file-access-processes.test.ts` outside this change)

Made with [Cursor](https://cursor.com)