### PR TITLE
Add recommended hotkeys setup

### DIFF
--- a/.cursor/commands/build-ready-tasks.md
+++ b/.cursor/commands/build-ready-tasks.md
@@ -1,0 +1,161 @@
+# Build ready tasks
+
+Implement ClickUp tickets from one list's `Build Ready` column as a sequence of focused commits and pull requests.
+
+Any text after `/build-ready-tasks` must be a ClickUp list URL or list ID.
+
+## Safety
+
+- Use the ClickUp MCP server for all ClickUp reads and updates. Before the first MCP call, read the relevant tool descriptors for `clickup_get_list`, `clickup_filter_tasks`, `clickup_get_task`, and `clickup_update_task`.
+- Do not use browser automation as a fallback for missing ClickUp MCP support.
+- Do not start if the current git working tree has uncommitted tracked changes or unrelated untracked files. Ask the user whether to commit, stash, or remove them first.
+- Never update git config, skip hooks, force push, use interactive git commands, reset, rebase, or amend unless the user explicitly asks.
+- Treat this command as explicit approval to create branches, implement work, commit, push, and open PRs for the selected Build Ready tickets only.
+- Stop the workflow on the first unresolved implementation, test, push, PR, or ClickUp blocker. Report the completed PRs, remaining groups, and the blocker.
+
+## Resolve the Build Ready tickets
+
+1. Parse the text after `/build-ready-tasks`.
+   - If it is missing, ask for a ClickUp list URL or list ID and stop.
+   - If it is a URL, extract the list ID when present. If the list cannot be resolved from the URL, ask for the list ID and stop.
+
+2. Get the list with ClickUp MCP:
+   - Use `clickup_get_list` with `list_id`.
+   - If the input is clearly a list name rather than an ID or URL, use `clickup_get_list` with `list_name`.
+
+3. Inspect the list's configured statuses.
+   - Match the status named `Build Ready`, ignoring only case and surrounding whitespace.
+   - If no matching status exists, say exactly: `There is no build ready column`
+   - After saying that, do nothing else.
+
+4. Retrieve every task in the list with the matched Build Ready status.
+   - Use `clickup_filter_tasks` with `list_ids: [<list id>]`, `statuses: [<exact Build Ready status>]`, `include_closed: false`, and `subtasks: true`.
+   - Paginate until all matching tasks are collected.
+   - If no tasks are in Build Ready, report that and stop.
+
+5. For each Build Ready task, fetch implementation context:
+   - Use `clickup_get_task` with `include: ["dependencies", "linked_tasks", "subtasks", "description", "checklists", "custom_fields"]` and `expand_statuses: true`.
+   - Record task ID, custom ID, title, URL, description summary, status, dependencies, linked tasks, subtasks, checklist size, priority, estimate if available, and available statuses.
+
+## Build the implementation plan
+
+Create a dependency graph using only the Build Ready tasks as in-scope implementation nodes.
+
+- A task with no in-scope blockers is a base dependency.
+- A task blocked by another Build Ready task must not be implemented before its blocker.
+- If a task is blocked by a task outside the Build Ready set, report the external blocker. Do not implement that task unless the dependency is clearly informational or already complete.
+- If a dependency cycle exists, report the cycle and stop.
+
+Classify each task before grouping:
+
+- **Base dependency:** Unlocks other Build Ready work.
+- **Small related task:** Similar area, low risk, and can share a PR without making review hard.
+- **Significant feature:** Large scope, multiple subsystems, many subtasks/checklist items, high estimate, risky migration, or broad user-facing behavior. Significant features get their own PR.
+- **Blocked:** Has unresolved blockers outside the current Build Ready plan.
+
+Group tasks in implementation order:
+
+1. Put base dependencies first, provided they are not too large.
+   - Group small, cohesive base dependencies into one PR when they unlock the same later work.
+   - Put a large base dependency in its own PR.
+2. As dependencies become unlocked, group similar small tickets together by feature area or code ownership.
+3. Put each significant feature in its own PR.
+4. Keep each group reviewable. If a group starts to require unrelated files, unrelated user flows, or a long test plan, split it.
+5. Prefer stacked PRs when later groups depend on unmerged code from earlier groups:
+   - Branch dependent groups from the prerequisite branch.
+   - Open the dependent PR with the prerequisite branch as its base.
+   - Report the intended merge order.
+
+Before implementing, show a short plan with:
+
+- The ordered PR groups
+- The tickets in each group
+- Which groups are stacked on earlier groups
+- Any blocked or skipped tickets and why
+
+Proceed without asking for extra confirmation unless the plan has ambiguity that could change the code architecture or release order.
+
+## Implement each group
+
+For each group, complete the full loop before starting the next group:
+
+1. Prepare the branch.
+   - Confirm the working tree is clean.
+   - Resolve the default base branch with `gh repo view --json defaultBranchRef,nameWithOwner`.
+   - For independent groups, create the branch from the default base branch.
+   - For dependent groups, create the branch from the prerequisite group branch.
+   - Name the branch using `git-workflow.mdc`, with the dominant prefix and a short description. Include a task ID when it helps traceability.
+
+2. Move the group's tickets out of Build Ready.
+   - Resolve an active-work status such as `In Progress` from the task's available statuses.
+   - If an active-work status exists, use `clickup_update_task` to move each group task there.
+   - If no active-work status exists, leave the tasks unchanged and report that status movement was skipped.
+
+3. Implement the group.
+   - Use the ticket descriptions, dependencies, and codebase as source material.
+   - Keep the edit scope limited to the group.
+   - Do not include unrelated cleanup.
+   - Add or update tests only when the ticket explicitly calls for them or the repo's rules require them.
+
+4. Verify the group.
+   - Run relevant tests, lint, build, or manual verification for the changed code.
+   - If verification requires a user-started app, service, or manual environment, stop and ask instead of starting it yourself.
+   - If verification fails, fix and rerun before committing.
+
+5. Commit the group.
+   - Stage only files relevant to the group.
+   - Use the required HEREDOC commit format.
+   - Write one conceptual past-tense message.
+   - Add one `Clickup Task: <id>` line for each ticket in the group.
+
+6. Push and open the PR.
+   - Push the branch with upstream tracking if needed.
+   - Create the PR with `gh pr create`.
+   - Use the default base branch for independent groups.
+   - Use the prerequisite group branch as the base for stacked groups.
+
+7. Move the group's tickets to review.
+   - Resolve the `Review` status from the task's available statuses.
+   - If a Review status exists, use `clickup_update_task` to move each group task there after the PR exists.
+   - If no Review status exists, leave the tasks unchanged and report that status movement was skipped.
+
+8. Report progress for the group:
+   - Branch
+   - Commit hash
+   - PR URL and base branch
+   - Tickets included
+   - Tests or verification run
+   - ClickUp status changes
+
+## PR body format
+
+```markdown
+## Summary
+
+- <What changed and why>
+
+## ClickUp
+
+- [<task name>](<task url>) - `<task id>`
+
+## Test plan
+
+- [x] <verification command or manual check>
+
+## Stack
+
+Base: `<base branch>`
+Depends on: `<prior PR URL or none>`
+```
+
+Omit `## Stack` only when the PR is independent and based on the default branch.
+
+## Final output
+
+When all possible groups are complete, show:
+
+- List name and Build Ready status used
+- PRs created in merge order
+- Tickets completed, skipped, or blocked
+- Verification summary
+- Any ClickUp statuses that could not be updated

--- a/.cursor/commands/commit.md
+++ b/.cursor/commands/commit.md
@@ -1,0 +1,79 @@
+# Commit and push
+
+Stage all relevant changes, write a commit message in the required format, commit, and push to the remote.
+
+Any text after `/commit` is optional context — e.g. a ClickUp task ID (`/commit 86abc1234`) or a hint about what changed.
+
+## Git safety
+
+- NEVER update the git config
+- NEVER run destructive/irreversible git commands (push --force, hard reset, etc.)
+- NEVER skip hooks (--no-verify, --no-gpg-sign, etc.)
+- NEVER force push to main/master — warn and stop if the push would require it
+- Avoid `git commit --amend` unless the user explicitly invoked `/commit` again to amend a commit you just created in this conversation that has not been pushed
+- Do not commit files that likely contain secrets (.env, credentials.json, etc.) — warn and exclude them
+- Never use git commands with the `-i` flag
+- If there are no changes to commit, report that and stop — do not create an empty commit
+
+## Steps
+
+1. Run in parallel:
+   - `git status` — see untracked and modified files
+   - `git diff` and `git diff --staged` — understand the full change set
+   - `git log -5 --oneline` — recent message context
+   - `git branch -vv` — confirm upstream tracking branch for push
+
+2. Stage all relevant changes (`git add` for modified/untracked files that belong in this commit). Do not stage secret or generated junk unless the user clearly intended it.
+
+3. Draft the commit message using the format below.
+
+4. Commit using a HEREDOC:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<past-tense verb>: <message>
+
+Clickup Task: <id>
+EOF
+)"
+```
+
+5. Push: `git push` (or `git push -u origin <branch>` if no upstream is set). Report the result.
+
+6. Run `git status` after push to confirm a clean state.
+
+## Commit message format
+
+**Prefix:** Start with an accurate past-tense verb, lowercase, followed by a colon and space (e.g. `added:`, `updated:`, `fixed:`, `redesigned:`, `removed:`).
+
+**Body:** Write 1–2 sentences describing the conceptual what, with emphasis on why. Each sentence after the prefix must start with a past-tense verb and remain entirely in past tense. Use active voice where natural.
+
+**Avoid:**
+- Passive openings (`was dropped`, `was added`)
+- Imperatives (`Fix`, `Rebound`, `Update`)
+- Present tense (`persists`, `allows`, `fixes`)
+- File lists or line-level diffs unless that is the conceptual what
+
+**ClickUp line (optional):** When a ClickUp task is relevant and known, add a blank line after the body, then:
+
+```
+Clickup Task: <ClickUp-task-ID>
+```
+
+Use a task ID from: text after `/commit`, the current conversation, or the branch name if it embeds one. Omit the ClickUp line if no task is known.
+
+**Example:**
+
+```
+fixed: Dropped hand tracking input during scene transitions because the OVRHand reference was destroyed on load. Rebounded the reference in Awake so input persisted across scenes.
+
+Clickup Task: 86abc1234
+```
+
+## Output
+
+When done, show:
+- The commit message used
+- Commit hash
+- Push result (remote and branch)
+- Any warnings (secrets skipped, no upstream, push rejected, etc.)

--- a/.cursor/commands/document.md
+++ b/.cursor/commands/document.md
@@ -1,0 +1,50 @@
+# Document current thread feature work
+
+Document the new or materially changed feature behavior implemented in this chat thread.
+
+Any text after `/document` is optional context — e.g. a feature name, task ID, or a hint about which part of the thread to document.
+
+## Scope
+
+- Document only behavior implemented or materially changed in the current chat thread.
+- Use the current conversation, uncommitted changes, commits created in this thread, tests, and implementation code as sources of truth.
+- Do not document unrelated branch history, speculative future behavior, or behavior you have not verified in code.
+- If the current-thread feature scope is unclear, ask a clarifying question before editing docs.
+
+## Steps
+
+1. Gather evidence:
+   - Review the user's `/document` context and the current conversation.
+   - Run `git status`, `git diff`, `git diff --staged`, and `git log -10 --oneline` to identify changes from this thread.
+   - Inspect relevant implementation and tests directly before writing.
+
+2. Choose documentation targets:
+   - Prefer existing docs under `docs/` that already describe the feature or interaction.
+   - Create a new focused doc page only when no existing page fits.
+   - Do not combine unrelated concepts into one doc page.
+
+3. Update docs:
+   - Explain why the feature exists before implementation details.
+   - Describe the user's mental model and the key flows.
+   - Include technical details that future maintainers need to avoid regressions.
+   - Use Mermaid diagrams for flows when they clarify the behavior.
+   - Add or update a "Technical Gotchas" section for non-obvious constraints.
+
+4. Add context comments:
+   - Add brief comments for feature intent, interaction rules, lifecycle ordering, persistence contracts, constraints, edge cases, and regression-sensitive decisions.
+   - Explain why functions, helpers, branches, and code snippets exist and why they are built a particular way.
+   - Default to adding a short comment when future maintainers would otherwise need thread history to preserve the behavior.
+   - Do not add comments that merely restate syntax or obvious assignments.
+
+5. Verify:
+   - Re-read changed docs and comments for accuracy against the implementation.
+   - Do not run app install/launch steps for documentation-only changes.
+   - Do not commit unless the user also invokes `/commit`.
+
+## Output
+
+When done, show:
+- Docs created or updated
+- Context comments added
+- Source evidence used (commits, diffs, tests, or files)
+- Any behavior intentionally not documented because it was outside the current thread

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -1,0 +1,108 @@
+# Create pull request
+
+Push the current branch (if needed) and open a pull request into the default base branch (usually `main`) using `gh`.
+
+Any text after `/pr` is optional context — e.g. a ClickUp task ID (`/pr 86abc1234`), a target base branch hint, or a note about what the PR covers.
+
+## Git safety
+
+- NEVER update the git config
+- NEVER run destructive/irreversible git commands (push --force, hard reset, etc.)
+- NEVER skip hooks (--no-verify, --no-gpg-sign, etc.)
+- NEVER force push to main/master — warn and stop if the push would require it
+- Do not commit as part of `/pr` — if there are uncommitted changes, warn and stop (use `/commit` first)
+- Never use git commands with the `-i` flag
+- If the branch has no commits ahead of the base branch, report that and stop — do not open an empty PR
+
+## Steps
+
+1. Run in parallel:
+   - `git status` — confirm working tree is clean (or only allow untracked files the user clearly intends to exclude)
+   - `git branch -vv` — current branch and upstream tracking
+   - `gh repo view --json defaultBranchRef,nameWithOwner` — default base branch and repo
+   - Resolve the merge-base base branch: use text after `/pr` if it names a base (e.g. `into develop`); otherwise use the repo default (`main` / `master`)
+   - `git log --oneline <base>...HEAD` — commits included in the PR
+   - `git diff <base>...HEAD` — full change set for the conceptual summary
+   - `gh pr view --json url,number,state 2>/dev/null` or `gh pr list --head $(git branch --show-current) --json url,number,state` — check for an existing PR on this branch
+
+2. If uncommitted tracked changes exist, stop and tell the user to `/commit` first.
+
+3. If a PR already exists for this branch, report its URL and stop unless the user clearly asked to update it.
+
+4. Collect **ClickUp task IDs** from (dedupe, preserve order):
+   - Text after `/pr`
+   - The current conversation
+   - The branch name (e.g. `feat/86abc1234-short-desc`)
+   - Commit bodies on `<base>...HEAD` — lines matching `Clickup Task: <id>` (case-insensitive)
+
+5. For each ClickUp task ID, resolve link and title:
+   - Prefer **ClickUp MCP** `clickup_get_task` when available — use the task `url` and `name` from the response
+   - If MCP is unavailable or lookup fails, use fallback URL `https://app.clickup.com/t/<task_id>` and title `<task_id>`
+
+6. Draft the PR:
+   - **Title:** One concise line — conceptual what changed, not a file list. Prefer the dominant theme across commits; use `/pr` hint text when provided.
+   - **Body:** Use the format below. Summary bullets must describe **why** and **what** at a conceptual level (not a file manifest). Commits list must include **every** commit on `<base>...HEAD`, newest first or oldest first — pick oldest-first ( chronological ) so readers follow the story.
+
+7. Push if needed: `git push` or `git push -u origin <branch>` when no upstream is set. Stop on push failure.
+
+8. Create the PR:
+
+```bash
+gh pr create --base <base> --head <branch> --title "<title>" --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+9. After the PR is created, move each linked ClickUp task to the list's **Review** status/column:
+   - Resolve the exact Review status when needed.
+   - Prefer **ClickUp MCP** `clickup_update_task` with `status`.
+   - Leave tasks unchanged if they are already in Review or a later review/done status.
+   - If MCP is unavailable or the Review status cannot be resolved, report that clearly and ask the user to move the task manually.
+
+10. Report the PR URL, title, base branch, commit count, ClickUp tasks linked, ClickUp tasks moved to Review, and any warnings (no ClickUp tasks found, MCP unavailable, skipped push, status update failed, etc.).
+
+## PR body format
+
+```markdown
+## Summary
+
+- <Conceptual bullet — what changed and why>
+- <Additional bullet if needed; usually 1–3 bullets total>
+
+## Commits
+
+- `<short-hash>` — <full first line of commit message>
+- `<short-hash>` — <full first line of commit message>
+
+## ClickUp
+
+- [<task name>](<task url>) — `<task id>`
+```
+
+**Summary:** Past tense, conceptual, emphasis on why. No file lists or line-level diffs unless essential to explain the change.
+
+**Commits:** One line per commit from `git log <base>...HEAD`. Use the abbreviated hash from `--oneline` (or `git log --format=%h`).
+
+**ClickUp:** One line per linked task with markdown link, display name, and task ID in backticks. If no task IDs were found, replace the section with:
+
+```markdown
+## ClickUp
+
+None linked.
+```
+
+## Optional test plan
+
+Add a `## Test plan` section **only** when the change has non-obvious verification steps (user flows, device testing, regression areas). Keep it a short checklist.
+
+## Output
+
+When done, show:
+- PR URL
+- PR title
+- Base ← head branches
+- Number of commits included
+- ClickUp tasks linked (IDs + URLs)
+- ClickUp tasks moved to Review (IDs + status), or why they were not moved
+- Any warnings

--- a/.cursor/commands/update-agent-tooling.md
+++ b/.cursor/commands/update-agent-tooling.md
@@ -1,0 +1,52 @@
+# Update agent tooling from reference repo
+
+Sync Cursor agent tooling from `_reference_ide-setup` into a target project.
+
+Any text after `/update-agent-tooling` is optional context, such as a target repo path, environment name, or specific tooling type to check.
+
+## Scope
+
+- Target the primary repository in the current workspace unless the user names another repo or path.
+- Use `_reference_ide-setup` as the source of truth for reusable agent tooling.
+- Pull in missing shared/common tooling from `shared/`.
+- Detect this project type, then pull in missing relevant tooling from the matching environment folder, such as `android-native/`, `react-native/`, `web-react/`, `obsidian-plugin/`, or `unity-mixed-reality/`.
+- Agent tooling includes Cursor commands, skills, MCP configuration, plugins, rules that are required by those tools, scripts/templates those tools depend on, and docs that explain how to use them.
+- Do not commit, push, or change branches unless the user explicitly asks.
+
+## Steps
+
+1. Resolve source and target:
+   - Find `_reference_ide-setup` in the workspace or as a sibling repo.
+   - Identify the target repo from the `/update-agent-tooling` context, or default to the primary repo in the workspace.
+   - If either repo is ambiguous or missing, ask for clarification before editing.
+
+2. Determine the environment:
+   - Prefer an explicit environment named after the command.
+   - Otherwise inspect project files, existing `.cursor/rules/`, README files, build files, and package metadata.
+   - If the project type is still unclear, ask before copying environment-specific tooling.
+
+3. Compare tooling:
+   - Check `shared/.cursor/commands/`, `shared/.cursor/skills/`, `shared/.cursor/mcp.json`, `shared/.cursor/plugins/`, plus any dependent shared docs, scripts, templates, or rules.
+   - Check the same paths under the matching environment folder.
+   - Compare against the target repo's `.cursor/commands/`, `.cursor/skills/`, `.cursor/mcp.json`, `.cursor/plugins/`, `docs/`, `scripts/`, and `templates/` as applicable.
+
+4. Copy missing relevant items:
+   - Create target directories only when needed.
+   - Copy missing files from `shared/` first, then from the environment folder.
+   - Merge `.cursor/mcp.json` carefully instead of replacing project-specific servers.
+   - Do not overwrite customized target files without reviewing the difference and asking for confirmation.
+   - Preserve project-specific placeholders and filled-in values. If a copied template contains placeholders, list them for the user to fill in.
+
+5. Verify:
+   - Re-read the copied or merged files.
+   - Run a read-only status/diff check to summarize what changed.
+   - Do not build or deploy for Cursor-tooling-only changes.
+
+## Output
+
+When done, show:
+- Target repo and detected environment
+- Shared tooling added or already present
+- Environment tooling added or already present
+- MCP/plugin merge notes
+- Any skipped files, conflicts, or placeholders that need user input

--- a/.cursor/rules/clickup.mdc
+++ b/.cursor/rules/clickup.mdc
@@ -1,0 +1,52 @@
+---
+description: ClickUp task tracking configuration for this repository
+alwaysApply: true
+---
+
+## ClickUp
+
+This project's tasks are tracked in ClickUp under:
+
+- **Workspace:** Workspace
+- **Space:** Products
+- **Folder:** `Ob: Project Browser`
+
+When referencing or creating ClickUp tasks, scope all queries and operations to the `Ob: Project Browser` folder unless the user specifies otherwise.
+
+### Lists within `Ob: Project Browser`
+
+- **`Backlog`** — reference only; do not action tasks from this list unless explicitly asked. It is a holding area, not current work.
+- **Release lists** (e.g. `PB: 0.4`, `PB: 0.5`, `PB: 0.6`, `PB: 0.7`) — represent current or future Project Browser release work. The lowest-version release list with actionable tasks is the active release unless the user specifies another list.
+- **Other named lists** — treat as current or future work unless context suggests otherwise.
+
+### Starting work on a task
+
+When told to start working on a ClickUp ticket (by ID, URL, or name), immediately move it to `In Progress` (or the list's equivalent active-work status) before any implementation — use ClickUp MCP (`clickup_update_task` with `status`) as the first action.
+
+- If the task is already `In Progress` or a later status such as `Review`, leave it unchanged.
+- If the list uses a different status name, resolve the correct value with `clickup_get_task` before updating.
+- If ClickUp MCP is unavailable, say so and ask the user to move the task manually; do not skip this step silently.
+
+### Opening a pull request
+
+When a pull request is opened for one or more ClickUp tickets, move each linked ticket to the list's `Review` status/column after the PR exists.
+
+- Resolve the exact Review status for the task's list when needed.
+- Use ClickUp MCP (`clickup_update_task` with `status`) to update each linked task.
+- If a linked task is already in `Review` or a later review/done status, leave it unchanged.
+- If ClickUp MCP is unavailable or the Review status cannot be resolved, report that clearly and ask the user to move the task manually; do not skip this step silently.
+
+### ClickUp tickets in one request
+
+When the user asks to complete one or more ClickUp tickets in a single request:
+
+1. Move each ticket to `In Progress` before implementation (same rules as above).
+2. Unless the user explicitly says to work on the current branch (or equivalent), create one new branch from `main` for all the work. Name it per `git-workflow.mdc` with a short description that covers the combined scope (e.g. `feat/card-browser-filtering`). Do not create one branch per ticket unless the user explicitly asks for separate branches.
+3. Implement and complete all requested tickets on that branch (new or current, per step 2).
+4. Commit the work on that branch. One commit per ticket is fine when changes are independent; one combined commit is fine when the work is tightly coupled. Include a `Clickup Task:` line for each ticket in the relevant commit message(s).
+5. Push the branch and open a pull request into `main` (use `/pr` or follow `.cursor/commands/pr.md`) when the work is complete, unless the user explicitly asked for separate branches or PRs.
+6. After the PR is created, move each linked ClickUp ticket to the list's `Review` status/column (same rules as above).
+
+When the user explicitly asks for separate branches (e.g. "one branch per ticket"), create a branch per ticket, commit each independently, and open one PR per branch into `main`.
+
+When the user explicitly asks to work on the current branch, skip creating a new branch; implement, commit, and open a PR from the current branch when the work is complete (unless they say otherwise).

--- a/.cursor/rules/committing-changes-with-git.mdc
+++ b/.cursor/rules/committing-changes-with-git.mdc
@@ -1,0 +1,79 @@
+---
+description: Commit safety protocol and required commit message format
+alwaysApply: true
+---
+
+# Committing Changes with Git
+
+> **Setup note:** This rule is intended as a **Cursor User Rule** (Settings → Rules → User Rules) so it applies across all repositories. It may also live as a project rule when copied from `_reference_ide-setup/shared/`. See `shared/docs/cursor-git-commit-setup.md` and root `README.md`.
+
+Only create commits when requested by the user. If unclear, ask first. When the user asks you to create a new git commit, follow these steps carefully:
+
+## Git Safety Protocol
+
+- NEVER update the git config
+- NEVER run destructive/irreversible git commands (like push --force, hard reset, etc.) unless the user explicitly requests them in the user query or in a different user rule
+- NEVER skip hooks (--no-verify, --no-gpg-sign, etc.) unless the user explicitly requests it in the user query or in a different user rule
+- NEVER run force push to main/master, warn the user if they request it
+- Avoid git commit --amend. ONLY use --amend when ALL conditions are met:
+  1. User explicitly requested amend, OR commit SUCCEEDED but pre-commit hook auto-modified files that need including
+  2. HEAD commit was created by you in this conversation (verify: `git log -1 --format='%an %ae'`)
+  3. Commit has NOT been pushed to remote (verify: git status shows "Your branch is ahead")
+- CRITICAL: If commit FAILED or was REJECTED by hook, NEVER amend — fix the issue and create a NEW commit
+- CRITICAL: If you already pushed to remote, NEVER amend unless the user explicitly requests it in the user query or in a different user rule (requires force push)
+- NEVER commit changes unless the user explicitly asks you to in the user query or in a different user rule. It is VERY IMPORTANT to only commit when explicitly asked, otherwise the user will feel that you are being too proactive.
+
+## Steps
+
+1. Run in parallel:
+   - `git status` — see all untracked files
+   - `git diff` and `git diff --staged` — see changes to be committed
+   - `git log -5 --oneline` — recent commit messages for context
+2. Analyze all staged changes and draft a commit message:
+   - Do not commit files that likely contain secrets (.env, credentials.json, etc.). Warn the user if they specifically request to commit those files
+   - Follow the Commit Message Format below
+   - Ensure the message accurately reflects the changes and their purpose
+3. Run sequentially:
+   - Add relevant untracked files to the staging area
+   - Commit the changes with the message
+   - Run `git status` after the commit completes to verify success
+4. If the commit fails due to pre-commit hook, fix the issue and create a NEW commit (see amend rules above)
+
+## Commit Message Format
+
+**Prefix:** Start with an accurate past-tense verb, lowercase, followed by a colon and space (e.g. `added:`, `updated:`, `fixed:`, `redesigned:`, `removed:`).
+
+**Body:** Write 1–2 sentences describing the conceptual what, with emphasis on why. Each sentence after the prefix must start with a past-tense verb and remain entirely in past tense. Use active voice where natural.
+
+**Avoid:**
+- Passive openings (`was dropped`, `was added`)
+- Imperatives (`Fix`, `Rebound`, `Update`)
+- Present tense (`persists`, `allows`, `fixes`)
+- File lists or line-level diffs unless that is the conceptual what
+
+**ClickUp line (optional):** When a ClickUp task is relevant and known, add a blank line after the body, then: `Clickup Task: <ClickUp-task-ID>`
+
+Example:
+
+```
+fixed: Dropped hand tracking input during scene transitions because the OVRHand reference was destroyed on load. Rebounded the reference in Awake so input persisted across scenes.
+
+Clickup Task: 86abc1234
+```
+
+## Important Notes
+
+- NEVER update the git config
+- NEVER run additional commands to read or explore code, besides git shell commands
+- DO NOT push to the remote repository unless the user explicitly asks you to do so in the user query or in a different user rule
+- Never use git commands with the `-i` flag (like git rebase -i or git add -i) since they require interactive input which is not supported
+- If there are no changes to commit, do not create an empty commit
+- ALWAYS pass the commit message via a HEREDOC:
+
+```bash
+git commit -m "$(cat <<'EOF'
+Commit message here.
+
+EOF
+)"
+```

--- a/.cursor/rules/documentation-and-context-comments.mdc
+++ b/.cursor/rules/documentation-and-context-comments.mdc
@@ -1,0 +1,22 @@
+---
+description: Documentation updates and context comments for feature work
+alwaysApply: true
+---
+
+# Documentation And Context Comments
+
+## Documentation
+
+Do not write or update documentation during ordinary implementation unless the user explicitly asks, invokes `/document`, or the current task is documentation-only.
+
+When documenting feature work, document only the feature behavior implemented or materially changed in the current chat thread. Use the implementation, tests, commits, and current conversation as sources of truth; do not document unrelated branch history.
+
+Keep documentation in `docs/` unless the project has a more specific established docs location. Prefer separate pages per concept or feature, and use Mermaid diagrams for flows when they clarify behavior.
+
+## Context Comments
+
+Add brief context comments proactively when implementing or changing features. Context is part of the feature: it helps future agents and developers understand intent and prevents accidental regressions on later branches.
+
+Comments should explain why a function, helper, branch, or code snippet exists and why it is built that way. Cover feature intent, interaction rules, lifecycle ordering, persistence contracts, constraints, edge cases, and regression-sensitive decisions.
+
+Default to adding a short context comment when new feature behavior, a conditional branch, or a helper would otherwise rely on thread history to understand. Avoid comments that merely restate syntax or obvious assignments.

--- a/.cursor/rules/documentation-standards.mdc
+++ b/.cursor/rules/documentation-standards.mdc
@@ -33,6 +33,6 @@ Every documentation page should follow this order:
 
 ## Planning
 
-After successful implementation, suggest that the user request relevant documentation be written or updated.
+After successful implementation, suggest `/document` when documenting the current thread's feature work would help future maintenance.
 
-Do **not** write or update documentation unless the user explicitly asks you to.
+Do **not** write or update documentation unless the user explicitly asks, invokes `/document`, or the current task is documentation-only.

--- a/.cursor/rules/editing-guidelines.mdc
+++ b/.cursor/rules/editing-guidelines.mdc
@@ -24,6 +24,6 @@ Do not remove `console.log` statements while actively making a change.
 
 ## Keep Documentation Accurate
 
-If the user asks you to write/update documentation (or you are already editing docs for the task), keep documentation accurate and consistent with the implementation.
+If the user asks you to write/update documentation, invokes `/document`, or you are already editing docs for the task, keep documentation accurate and consistent with the implementation.
 
-After successful implementation, suggest that the user request documentation be written/updated, but do **not** write or update documentation unless the user explicitly asks you to.
+After successful implementation, suggest `/document` when documenting the current thread's feature work would help future maintenance. Do **not** write or update documentation unless the user explicitly asks, invokes `/document`, or the current task is documentation-only.

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -28,3 +28,9 @@ Rules:
 ## Branch Lifecycle
 
 Delete branches immediately after they are merged to `main`. Do not let stale branches accumulate.
+
+## AI Commit Policy
+
+Never commit, push, amend, rebase, reset, or otherwise modify git history or branches unless the user explicitly asks for it in their message. Staging and local file edits are fine; any action that would create or change a git commit or branch requires explicit instruction.
+
+When committing, follow the message format and safety protocol in `committing-changes-with-git.mdc`. For commit-and-push in one step, the user may invoke the `/commit` slash command (see `docs/cursor-git-commit-setup.md`). For opening a PR, the user may invoke `/pr` (see `.cursor/commands/pr.md`).

--- a/.cursor/rules/planning-workflow.mdc
+++ b/.cursor/rules/planning-workflow.mdc
@@ -7,9 +7,9 @@ alwaysApply: true
 
 ## Suggest Documentation After Implementation
 
-After successful implementation, suggest that the user request relevant documentation be written or updated.
+After successful implementation, suggest `/document` when documenting the current thread's feature work would help future maintenance.
 
-Do **not** write or update documentation unless the user explicitly asks you to.
+Do **not** write or update documentation unless the user explicitly asks, invokes `/document`, or the current task is documentation-only.
 
 ## Use Mermaid for Diagrams
 
@@ -26,4 +26,4 @@ A well-formed plan should:
 1. State the goal and motivation
 2. Break the work into discrete, ordered steps
 3. Call out any risks, trade-offs, or open questions
-4. End with suggesting the user request documentation (do not write docs unless asked)
+4. End with suggesting `/document` when docs would help future maintenance

--- a/.cursor/rules/target-device-build-and-deploy.mdc
+++ b/.cursor/rules/target-device-build-and-deploy.mdc
@@ -1,0 +1,48 @@
+---
+description: Build and deploy after changes only to the intended connected device class
+alwaysApply: true
+---
+
+# Target Device Build And Deploy
+
+After completing any change that can affect a buildable or runnable artifact, build and deploy before finishing. Do not wait for the user to ask. For documentation-only, Cursor-rule-only, or chat-only work, state that no deployable artifact changed.
+
+## Environment-Specific Exceptions
+
+Unity and React Native projects have their own build, deploy, and device-selection workflows. For those project types, this shared rule establishes the safety principle but does not authorize generic deploy commands.
+
+- **Unity:** Follow the Unity environment rules, skills, and project scripts. Do not trigger Unity builds, deploys, or Play mode yourself when the project says those steps are the user's responsibility. For XR/VR Unity projects, only use documented headset tooling and never substitute a generic Android deploy.
+- **React Native / Expo:** Use the project's React Native build scripts and device-selection flow. Do not invoke `eas build`, `expo run`, `expo start`, Gradle, Xcode, `adb`, or `xcrun` directly unless the React Native rules or scripts explicitly call for it.
+
+When an environment-specific workflow handles device selection internally, do not add a second generic device-targeting pass. Still refuse to deploy if the selected or visible target is clearly the wrong class for the project.
+
+## Identify The Intended Device
+
+Before deploying, determine the project's intended device class from project rules, README files, build configuration, package metadata, and existing deploy commands.
+
+Examples:
+- Virtual reality projects must deploy only to connected VR hardware or an explicitly configured VR simulator.
+- Mobile phone projects must deploy only to connected phone hardware or the project's explicitly configured phone simulator.
+- Desktop, web, plugin, and embedded projects must use their own documented runtime target instead of borrowing another project's device.
+
+If the intended device class is unclear, ask the user before deploying.
+
+## Check Connected Devices
+
+Always list connected devices with the platform's normal tooling before deploy, then choose only a device that matches the intended device class.
+
+Examples:
+- Android/mobile: use `adb devices -l` or the project's existing mobile tooling, and confirm the device is a phone when the project is phone-targeted.
+- Android/VR: use `adb devices -l`, vendor tools, or project-specific VR tooling, and confirm the model is VR hardware such as Quest, Pico, Vive Focus, or the project's documented headset.
+- iOS/mobile: use `xcrun devicectl list devices`, Xcode tooling, or project scripts, and confirm the target is an iPhone/iPad when the project is mobile-targeted.
+- Web/desktop/plugin: use the project-specific local runtime or test harness documented for that environment.
+
+Never deploy to a connected device merely because it is available. If no matching device is connected, or if multiple matching devices are connected and the target is ambiguous, stop and report the available devices instead of deploying.
+
+## Build, Deploy, Verify
+
+Use the project's documented build and deploy commands. If the project defines multiple app packages or build channels, select the documented channel for the situation instead of defaulting to a production package. Feature branches and PRs should prefer a safe dev/staging package when available; production packages should be reserved for main/release work or explicit production checks.
+
+After deploy, launch or exercise the selected package enough to verify that the new build is running on the selected target, then report the selected device, package/channel, and verification result.
+
+If build or deploy fails, read the full error, identify the root cause, fix it when it is in scope, and retry. Do not leave a build or deploy failure unresolved without explaining the blocker.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,7 +78,17 @@ Every documentation page follows this order:
 
 Use Mermaid diagrams for flows and architecture. Prefer Mermaid over ASCII art or prose descriptions.
 
-After successful implementation, suggest that the user request relevant documentation be written or updated. Do **not** write or update documentation unless the user explicitly asks you to.
+After successful implementation, suggest `/document` when documenting the current thread's feature work would help future maintenance. Do **not** write or update documentation unless the user explicitly asks, invokes `/document`, or the current task is documentation-only.
+
+---
+
+## Documentation And Context Comments
+
+Do not write or update documentation during ordinary implementation unless the user explicitly asks, invokes `/document`, or the current task is documentation-only.
+
+When documenting feature work, document only the feature behavior implemented or materially changed in the current chat thread. Use the implementation, tests, commits, and current conversation as sources of truth; do not document unrelated branch history.
+
+Add brief context comments proactively when implementing or changing features. Comments should explain why a function, helper, branch, or code snippet exists and why it is built that way. Avoid comments that merely restate syntax or obvious assignments.
 
 ---
 
@@ -92,7 +102,7 @@ After successful implementation, suggest that the user request relevant document
 
 **Debug mode rule:** Never remove logging added for debugging until a final test has been run that shows through the logs that the problem has been fixed. Do not assume a fix has worked without this confirmation.
 
-**Keep documentation accurate.** If the user asks you to write/update documentation (or you are already editing docs for the task), keep documentation accurate and consistent with the implementation. After successful implementation, suggest that the user request documentation be written/updated, but do **not** write or update documentation unless the user explicitly asks you to.
+**Keep documentation accurate.** If the user asks you to write/update documentation, invokes `/document`, or you are already editing docs for the task, keep documentation accurate and consistent with the implementation. After successful implementation, suggest `/document` when documenting the current thread's feature work would help future maintenance. Do **not** write or update documentation unless the user explicitly asks, invokes `/document`, or the current task is documentation-only.
 
 ---
 
@@ -124,6 +134,32 @@ Branch format: `<prefix>/<short-description>` in kebab-case.
 
 ---
 
+## ClickUp
+
+This project's tasks are tracked in ClickUp under workspace `Workspace`, space `Products`, folder `Ob: Project Browser`. Scope ClickUp queries and operations to that folder unless the user specifies otherwise.
+
+Use the `Backlog` list as reference only unless explicitly asked. Treat release lists such as `PB: 0.4`, `PB: 0.5`, `PB: 0.6`, and `PB: 0.7` as current or future Project Browser release work.
+
+When starting a ClickUp ticket, move it to `In Progress` before implementation when ClickUp MCP is available. When a PR is opened for linked ClickUp tickets, move each linked ticket to `Review` after the PR exists. If the status cannot be resolved or ClickUp MCP is unavailable, report that clearly and ask the user to move the task manually.
+
+---
+
+## Committing Changes With Git
+
+Only create commits when requested by the user. Never update git config, skip hooks, force push to `main`/`master`, use interactive git commands, or amend unless the explicit safety conditions in `.cursor/rules/committing-changes-with-git.mdc` are met.
+
+When committing, inspect `git status`, unstaged/staged diffs, and recent commits first. Do not commit secrets or generated junk unless clearly intended. Use a HEREDOC commit message with the required format:
+
+```text
+fixed: Described the conceptual change in past tense and explained why it mattered. Kept every sentence in past tense.
+
+Clickup Task: <optional-id>
+```
+
+Do not push unless the user explicitly asks, or they invoke the `/commit` command, which is defined as commit-and-push workflow.
+
+---
+
 ## Naming Conventions
 
 Every name must be self-explanatory without needing to trace the surrounding context.
@@ -140,9 +176,9 @@ Loop indices (`i`, `j`) are acceptable only in trivially small, obvious loops.
 
 ## Planning Workflow
 
-- After successful implementation, suggest that the user request relevant documentation be written or updated (do **not** write/update docs unless explicitly asked)
+- After successful implementation, suggest `/document` when documenting the current thread's feature work would help future maintenance (do **not** write/update docs unless explicitly asked, `/document` is invoked, or the current task is documentation-only)
 - Use Mermaid format for all diagrams in plans and documentation
-- A well-formed plan states the goal, breaks work into discrete steps, calls out risks, and ends with suggesting the user request documentation
+- A well-formed plan states the goal, breaks work into discrete steps, calls out risks, and ends with suggesting `/document` when docs would help future maintenance
 
 ---
 

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -68,6 +68,19 @@ if (isProjectPage) chosenAtom = projectPageStatelessSettingsAtom;
 
 Use `React.useMemo` when it is needed to preserve identity for derived objects, derived atoms, or expensive computations.
 
+## JSX optional branches
+
+When the **false** branch is only **`null`**, prefer **`{condition && (…)}`** over **`{condition ? (…) : null}`**.
+
+## Imports section divider (`*.ts` / `*.tsx`)
+
+When the file contains any **`import`** or **`import type`** statements:
+
+1. Group **all** import lines at the **top** (after an optional shebang, **`/// <reference … />`**, or other required first-line tooling headers).
+2. Immediately after the last import, add **two identical** full lines of slash characters (same pattern as elsewhere in this repo, e.g. **`//////////`**), **then exactly one blank line**, then everything else (types, exports, implementation).
+
+**Omit** this divider if the file has **no** `import` statements.
+
 ## Branch Comments Go Inside the Branch
 
 Place comments that explain a branch at the **start of that branch**, not before the `if` statement.
@@ -90,48 +103,72 @@ if (isAdmin) {
 
 Projects may have two distinct UI layer types — be deliberate about which you use:
 
-- **Framework components** (React components, JSX) — use for all interactive UI and anything that needs state or reactivity
-- **Host/native elements** (platform-native APIs like `document.createElement` or Obsidian's `createEl`) — use only when the platform requires it
+- **Framework components** (e.g. React components, JSX) — use for all interactive UI and anything that needs state or reactivity
+- **Host/native elements** (e.g. `document.createElement`, platform-native APIs like Obsidian's `createEl`) — use only when the platform requires it (settings panels, modals driven by the host platform)
 
 Do not mix layers arbitrarily. Follow the established pattern in the project.
 
+## Single `props` parameter (no destructuring)
+
+When a function’s inputs are a **single object** (React function components, render props, and similar), define it with **exactly one parameter** named **`props`**, typed as that object.
+
+- **Do not** destructure in the parameter list (e.g. `({ title, onClose }) =>`).
+- **Do not** unpack `props` in the body (e.g. `const { title, onClose } = props`) only to use those fields.
+- **Always** read fields as **`props.fieldName`** so anything coming from the caller is visibly prefixed with `props.`.
+
+```tsx
+// ❌ BAD
+export const Example: React.FC<ExampleProps> = ({ title, onClose }) => (
+    <Box onClick={onClose}>{title}</Box>
+);
+
+// ❌ BAD
+export const Example: React.FC<ExampleProps> = (props) => {
+    const { title, onClose } = props;
+    return <Box onClick={onClose}>{title}</Box>;
+};
+
+// ✅ GOOD
+export const Example: React.FC<ExampleProps> = (props) => (
+    <Box onClick={props.onClose}>{props.title}</Box>
+);
+```
+
+**Out of scope:** zero-argument functions, multiple **positional** parameters, or a single **non-object** parameter (e.g. `id: string`) — use normal signatures there.
+
+## Props `interface` immediately before the function
+
+When a function takes a single **`props`** object, declare its shape as a **named `export interface`** placed **immediately above** that function (nothing else between the interface and the function).
+
+- Name the interface **`{ComponentOrFunctionName}Props`** (e.g. `SettingsRowProps` before `SettingsRow`).
+- Prefer **`interface`** for that object; do not replace it with only an inline anonymous type on the parameter when this component or function owns the shape.
+- If the **same** props shape is shared across modules, define or import a **named** props interface; avoid an unnamed object type on `props`.
+
+```tsx
+export interface ExamplePanelProps {
+    title: string;
+    onClose: () => void;
+}
+
+/** Renders a titled panel with a close control. */
+export const ExamplePanel: React.FC<ExamplePanelProps> = (props) => (
+    <Box onClick={props.onClose}>{props.title}</Box>
+);
+```
+
+## Minimal TSDoc on every named function
+
+Every **named** function (`function foo`, exported or file-local) and every **`const` binding** whose value is a function or React component must have a **TSDoc** block **`/** … */`** **directly above** that declaration.
+
+- Keep it **minimal**: usually **one short sentence** (what it does or what the component shows). Add `@param` / `@returns` only when a single sentence is not enough.
+- **Omit** TSDoc for **inline** function expressions passed as arguments (e.g. `.map((id) => id)`, short `onClick` lambdas) when a comment would only repeat the code.
+
 ## Colocate Styles
 
-Place style definitions in the same folder as the component they style. Do not keep styles in a global folder unless they are genuinely global design tokens.
+Place style definitions (CSS modules, SCSS files, `StyleSheet` objects) in the same folder as the component they style. Do not keep styles in a separate global styles folder unless they are genuinely global tokens.
 
 ## State Management
 
-- Use reactive state (Jotai, Zustand, React state) for UI and cross-component concerns
-- Use structured session state (Redux Toolkit) for app-level workflow state that needs defined actions
+- Use reactive state (e.g. Jotai, Zustand, React state) for UI and cross-component concerns
+- Use session/operational state (e.g. Redux Toolkit) for app-level workflow state that needs structured actions
 - Follow whichever pattern is already established in the project
-
----
-
-# UI and Styling
-
-## Use the Theme System
-
-Pull all visual tokens — colors, spacing, typography, border radii, animation timings — from the project's established theme system. Do not hardcode values.
-
-```ts
-// ❌ BAD
-const styles = { color: '#3a86ff', fontSize: 14, padding: 12 };
-
-// ✅ GOOD
-const { colors, spacing, typography } = useTheme();
-const styles = { color: colors.primary, fontSize: typography.body, padding: spacing.md };
-```
-
-## No Inline Styles Except Truly Dynamic Values
-
-Avoid inline styles. The only acceptable exception is a value computed at runtime that cannot be expressed statically (e.g. a width derived from a live measurement).
-
-## Follow the Project's Style API
-
-Use whichever style API the project has established:
-
-- React Native: `StyleSheet.create()` with `useTheme()`
-- Web: CSS modules, `styled-components`, or utility classes from the design system
-- Ignite: `useAppTheme()`, `themed()`, `ThemedStyle<T>` with bare JS objects
-
-Do not introduce a new styling approach without a clear reason.

--- a/.github/instructions/ui-and-styling.instructions.md
+++ b/.github/instructions/ui-and-styling.instructions.md
@@ -1,7 +1,5 @@
 ---
-description: Obsidian plugin UI and styling conventions
-globs: **/*.{tsx,jsx,ts,js,scss,css}
-alwaysApply: false
+applyTo: "**/*.{tsx,jsx,ts,js,scss,css}"
 ---
 
 # Obsidian Plugin UI and Styling

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ If you’re new to the codebase or the plugin’s mental model, start with **Ove
 - [Project Pages FAB](project-pages-fab.md): the in-editor floating action button for jumping between project pages.
 - [File type visibility](file-type-visibility.md): control what file types appear in the Card Browser and in the pages menu.
 - [Settings](settings.md): access/behaviour and display settings that change how the plugin feels.
+- [Recommended hotkeys](recommended-hotkeys.md): reviewing and applying suggested shortcuts from plugin settings.
 
 ## Contributing / maintenance
 

--- a/docs/recommended-hotkeys.md
+++ b/docs/recommended-hotkeys.md
@@ -1,0 +1,79 @@
+# Recommended hotkeys
+
+Guide to the in-plugin flow for reviewing and applying Project Browser shortcut recommendations.
+
+## Why it exists
+
+Obsidian no longer ships default hotkeys for third-party plugins. Project Browser still relies on a small set of shortcuts for the state menu and state cycling, so the plugin exposes **recommended** chords users can apply when they do not conflict with existing bindings.
+
+The modal lets users apply shortcuts **one at a time**, see conflicts before overriding, and refresh the row immediately after a successful apply—without opening Obsidian’s global Hotkeys settings.
+
+## Conceptual understanding
+
+Three commands share the same mental model across **projects, notes, and pages**:
+
+| Action | Command | Recommended chord |
+|---|---|---|
+| Show or hide the state menu | Toggle state menu | Mod+Shift+S |
+| Move to the previous state | Apply previous state | Mod+Shift+Left arrow |
+| Move to the next state | Apply next state | Mod+Shift+Right arrow |
+
+State cycling uses whichever state list applies to the **active file** (standard note states vs project page states). Command names in the modal are hardcoded so they stay generic; they are not prefixed with “Project Browser:” like Obsidian’s command palette labels.
+
+In the modal UI, **Mod** is shown as **Command** on macOS and **Control** on Windows and Linux.
+
+## Flows
+
+### Open the modal
+
+```mermaid
+flowchart LR
+    A[Plugin settings] --> B[Setup and troubleshoot]
+    B --> C[Recommended hotkeys button]
+    C --> D[Recommended Hotkeys modal]
+```
+
+The button sits on the same row as “View recent changes” and “Rewatch welcome tips”. It is available on mobile as well (for example iPad with an external keyboard).
+
+### Apply one recommendation
+
+```mermaid
+flowchart TD
+    A[User clicks Apply or Override] --> B[Load merged hotkey config]
+    B --> C[Remove chord from conflicting commands]
+    C --> D[Write .obsidian/hotkeys.json]
+    D --> E[Call hotkeyManager.setHotkeys per changed command]
+    E --> F[hotkeyManager.save]
+    F --> G[Update in-memory cache and re-render row]
+    G --> H{Success?}
+    H -->|Yes| I[Button shows Applied]
+    H -->|No| J[Notice with manual Hotkeys settings hint]
+```
+
+Each row shows:
+
+1. **Line 1:** action name (e.g. “Toggle state menu”)
+2. **Line 2:** accent-colored chord, then a faint status in brackets—`(No conflict found.)`, `(Already applied.)`, or a conflict message
+
+## Technical details
+
+- **Entry point:** `Recommended hotkeys` button in `insertSetupTroubleshootSection()` (`src/tabs/settings-tab/settings-tab.ts`).
+- **Modal:** `RecommendedHotkeysModal` (`src/modals/recommended-hotkeys-modal/recommended-hotkeys-modal.ts`).
+- **Recommendations:** `RECOMMENDED_HOTKEYS` constant maps command IDs to display names and chord definitions.
+- **Persistence:** writes vault `.obsidian/hotkeys.json` via `vault.adapter`, then syncs runtime through Obsidian’s `hotkeyManager`.
+- **Conflict detection:** scans all commands in the merged config; matching chords on other commands surface as `(Conflicts with …)`.
+- **Override behaviour:** applying a recommendation removes that chord from any other command first, then assigns it to the Project Browser command.
+- **Command registration:** `src/commands/toggle-state-menu.ts` and `src/commands/cycle-state.ts` register the underlying commands; cycle commands call `getStateSettingsForFile()` so scope follows the active file.
+
+## Technical Gotchas
+
+- **`hotkeyManager.customKeys` is read-only** in current Obsidian builds. Assigning to it throws and breaks apply + modal refresh. Sync must use `setHotkeys(commandId, hotkeys)` for each changed command, then `save()`.
+- **Display names vs Obsidian names:** the modal must use `commandName` from `RECOMMENDED_HOTKEYS`, not `app.commands`, or rows pick up the “Project Browser: …” prefix.
+- **Modifier normalization:** persisted hotkeys may use `Mod`, `Ctrl`, or `Meta`. Compare with normalized modifiers and uppercase single-character keys when detecting “Already applied.”
+- **In-memory cache:** after apply, `hotkeyConfig` is updated before re-render so the row reflects the new state without closing the modal.
+- **Failure notice:** on error, the user sees a notice ending with: “If this persists, edit the hotkeys manually in the Obsidian Hotkeys settings.”
+
+## Related
+
+- [Settings](settings.md)
+- [States and sections](states-and-sections.md)

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -26,6 +26,10 @@ You can enable a command palette entry and/or a ribbon icon to open the Card Bro
 
 Controls whether the in-note State Menu is shown by default when you open a note.
 
+### Recommended hotkeys
+
+Under **Setup & troubleshoot**, the **Recommended hotkeys** button opens a modal where users can review and apply suggested shortcuts for the state menu and state cycling commands. See [Recommended hotkeys](recommended-hotkeys.md) for the full flow, chord list, and implementation notes.
+
 ## Display settings
 
 ### Use Aliases

--- a/src/commands/cycle-state.ts
+++ b/src/commands/cycle-state.ts
@@ -14,7 +14,8 @@ export async function registerCycleStateCommands() {
 
     plugin.addCommand({
         id: 'cycle-state-forward',
-		name: `Step note's state forward`,
+		// Generic name: scope (note vs project page) is resolved from the active file at runtime.
+		name: 'Apply next state',
         icon: ICON_STEP_STATE_FORWARD,
         editorCallback: (editor: Editor) => {
             const file = plugin.app.workspace.getActiveFile();
@@ -30,7 +31,8 @@ export async function registerCycleStateCommands() {
 
     plugin.addCommand({
         id: 'cycle-state-backward',
-		name: `Step note's state backward`,
+		// Generic name: scope (note vs project page) is resolved from the active file at runtime.
+		name: 'Apply previous state',
         icon: ICON_STEP_STATE_BACKWARD,
         editorCallback: (editor: Editor) => {
             const file = plugin.app.workspace.getActiveFile();

--- a/src/modals/recommended-hotkeys-modal/recommended-hotkeys-modal.scss
+++ b/src/modals/recommended-hotkeys-modal/recommended-hotkeys-modal.scss
@@ -1,0 +1,17 @@
+.ddc_pb_recommended-hotkey-chord {
+    color: var(--interactive-accent);
+    font-weight: 500;
+}
+
+.ddc_pb_recommended-hotkey-plus {
+    color: var(--text-muted);
+}
+
+.ddc_pb_recommended-hotkey-status {
+    color: var(--text-faint);
+    font-size: var(--font-ui-smaller);
+}
+
+.ddc_pb_recommended-hotkey-line {
+    margin-top: var(--size-2-1);
+}

--- a/src/modals/recommended-hotkeys-modal/recommended-hotkeys-modal.ts
+++ b/src/modals/recommended-hotkeys-modal/recommended-hotkeys-modal.ts
@@ -1,0 +1,199 @@
+import { Modal, Notice, Setting } from "obsidian";
+import { getGlobals } from "src/logic/stores";
+
+interface ObsidianHotkey {
+    modifiers?: string[];
+    key: string;
+}
+
+interface RecommendedHotkey {
+    commandId: string;
+    commandName: string;
+    hotkey: ObsidianHotkey;
+}
+
+type HotkeyConfig = Record<string, ObsidianHotkey[]>;
+
+const RECOMMENDED_HOTKEYS: RecommendedHotkey[] = [
+    {
+        commandId: 'project-browser:toggle-state-menu',
+        commandName: 'Toggle state menu',
+        hotkey: { modifiers: ['Mod', 'Shift'], key: 'S' },
+    },
+    {
+        commandId: 'project-browser:cycle-state-backward',
+        commandName: "Step note's state backward",
+        hotkey: { modifiers: ['Mod', 'Shift'], key: 'ArrowLeft' },
+    },
+    {
+        commandId: 'project-browser:cycle-state-forward',
+        commandName: "Step note's state forward",
+        hotkey: { modifiers: ['Mod', 'Shift'], key: 'ArrowRight' },
+    },
+];
+
+export class RecommendedHotkeysModal extends Modal {
+    constructor() {
+        const { plugin } = getGlobals();
+        super(plugin.app);
+    }
+
+    onOpen(): void {
+        this.titleEl.setText('Apply recommended hotkeys');
+        void this.render();
+    }
+
+    onClose(): void {
+        this.titleEl.empty();
+        this.contentEl.empty();
+    }
+
+    private async render(): Promise<void> {
+        const hotkeyConfig = await this.loadHotkeyConfig();
+        const commandNames = this.getCommandNames();
+        this.contentEl.empty();
+
+        this.contentEl.createEl('p', {
+            text: 'Review each recommended hotkey before applying it. If a hotkey is already assigned elsewhere, you can override that one shortcut without changing the others.',
+        });
+
+        for (const recommendation of RECOMMENDED_HOTKEYS) {
+            const conflict = this.findConflict(hotkeyConfig, recommendation);
+            const isApplied = this.commandHasHotkey(hotkeyConfig, recommendation.commandId, recommendation.hotkey);
+            const commandName = commandNames[recommendation.commandId] ?? recommendation.commandName;
+            const hotkeyLabel = this.formatHotkey(recommendation.hotkey);
+
+            new Setting(this.contentEl)
+                .setName(`${commandName}: ${hotkeyLabel}`)
+                .setDesc(
+                    isApplied
+                        ? 'Already applied.'
+                        : conflict
+                            ? `Conflicts with ${commandNames[conflict] ?? conflict}.`
+                            : 'No conflict found.',
+                )
+                .addButton((button) => {
+                    button.setButtonText(isApplied ? 'Applied' : conflict ? 'Override' : 'Apply');
+                    button.setDisabled(isApplied);
+                    if (!isApplied) button.setCta();
+                    button.onClick(() => {
+                        void this.applyHotkey(recommendation);
+                    });
+                });
+        }
+    }
+
+    private async applyHotkey(recommendation: RecommendedHotkey): Promise<void> {
+        const hotkeyConfig = await this.loadHotkeyConfig();
+
+        // Obsidian stores custom hotkeys by command id. Remove the chosen chord from
+        // other commands first so applying a recommendation is a deliberate override.
+        for (const commandId of Object.keys(hotkeyConfig)) {
+            if (commandId === recommendation.commandId) continue;
+            hotkeyConfig[commandId] = hotkeyConfig[commandId].filter(
+                (hotkey) => !this.hotkeysMatch(hotkey, recommendation.hotkey),
+            );
+            if (hotkeyConfig[commandId].length === 0) {
+                delete hotkeyConfig[commandId];
+            }
+        }
+
+        hotkeyConfig[recommendation.commandId] = [recommendation.hotkey];
+        await this.saveHotkeyConfig(hotkeyConfig);
+        this.syncHotkeyManager(hotkeyConfig);
+        new Notice(`Applied ${this.formatHotkey(recommendation.hotkey)} to ${recommendation.commandName}.`);
+        await this.render();
+    }
+
+    private async loadHotkeyConfig(): Promise<HotkeyConfig> {
+        const { plugin } = getGlobals();
+        const hotkeysPath = this.getHotkeysPath();
+        if (!(await plugin.app.vault.adapter.exists(hotkeysPath))) {
+            return {};
+        }
+
+        const rawConfig = await plugin.app.vault.adapter.read(hotkeysPath);
+        if (!rawConfig.trim()) return {};
+        return JSON.parse(rawConfig) as HotkeyConfig;
+    }
+
+    private async saveHotkeyConfig(hotkeyConfig: HotkeyConfig): Promise<void> {
+        const { plugin } = getGlobals();
+        await plugin.app.vault.adapter.write(
+            this.getHotkeysPath(),
+            JSON.stringify(hotkeyConfig, null, '\t'),
+        );
+    }
+
+    private getHotkeysPath(): string {
+        const { plugin } = getGlobals();
+        const vault = plugin.app.vault as typeof plugin.app.vault & { configDir: string };
+        return `${vault.configDir}/hotkeys.json`;
+    }
+
+    private syncHotkeyManager(hotkeyConfig: HotkeyConfig): void {
+        const hotkeyManager = (this.app as typeof this.app & {
+            hotkeyManager?: {
+                customKeys?: HotkeyConfig;
+                setHotkeys?: (commandId: string, hotkeys: ObsidianHotkey[]) => void;
+                save?: () => void;
+            };
+        }).hotkeyManager;
+
+        if (!hotkeyManager) return;
+        hotkeyManager.customKeys = hotkeyConfig;
+        for (const recommendation of RECOMMENDED_HOTKEYS) {
+            hotkeyManager.setHotkeys?.(
+                recommendation.commandId,
+                hotkeyConfig[recommendation.commandId] ?? [],
+            );
+        }
+        hotkeyManager.save?.();
+    }
+
+    private getCommandNames(): Record<string, string> {
+        const commands = (this.app as typeof this.app & {
+            commands?: { commands?: Record<string, { name?: string }> };
+        }).commands?.commands ?? {};
+
+        return Object.fromEntries(
+            Object.entries(commands).map(([commandId, command]) => [
+                commandId,
+                command.name ?? commandId,
+            ]),
+        );
+    }
+
+    private findConflict(
+        hotkeyConfig: HotkeyConfig,
+        recommendation: RecommendedHotkey,
+    ): string | null {
+        for (const [commandId, hotkeys] of Object.entries(hotkeyConfig)) {
+            if (commandId === recommendation.commandId) continue;
+            if (hotkeys.some((hotkey) => this.hotkeysMatch(hotkey, recommendation.hotkey))) {
+                return commandId;
+            }
+        }
+        return null;
+    }
+
+    private commandHasHotkey(
+        hotkeyConfig: HotkeyConfig,
+        commandId: string,
+        hotkeyToFind: ObsidianHotkey,
+    ): boolean {
+        return hotkeyConfig[commandId]?.some((hotkey) => this.hotkeysMatch(hotkey, hotkeyToFind)) ?? false;
+    }
+
+    private hotkeysMatch(left: ObsidianHotkey, right: ObsidianHotkey): boolean {
+        return left.key === right.key && this.normalizeModifiers(left).join('|') === this.normalizeModifiers(right).join('|');
+    }
+
+    private normalizeModifiers(hotkey: ObsidianHotkey): string[] {
+        return [...(hotkey.modifiers ?? [])].sort();
+    }
+
+    private formatHotkey(hotkey: ObsidianHotkey): string {
+        return [...(hotkey.modifiers ?? []), hotkey.key].join('+');
+    }
+}

--- a/src/modals/recommended-hotkeys-modal/recommended-hotkeys-modal.ts
+++ b/src/modals/recommended-hotkeys-modal/recommended-hotkeys-modal.ts
@@ -1,4 +1,5 @@
-import { Modal, Notice, Setting } from "obsidian";
+import { Modal, Notice, Platform, Setting } from "obsidian";
+import "./recommended-hotkeys-modal.scss";
 import { getGlobals } from "src/logic/stores";
 
 interface ObsidianHotkey {
@@ -14,6 +15,8 @@ interface RecommendedHotkey {
 
 type HotkeyConfig = Record<string, ObsidianHotkey[]>;
 
+// Display names are hardcoded so the modal stays generic (projects, notes, pages)
+// and avoids Obsidian's "Project Browser: …" command palette prefix.
 const RECOMMENDED_HOTKEYS: RecommendedHotkey[] = [
     {
         commandId: 'project-browser:toggle-state-menu',
@@ -22,30 +25,52 @@ const RECOMMENDED_HOTKEYS: RecommendedHotkey[] = [
     },
     {
         commandId: 'project-browser:cycle-state-backward',
-        commandName: "Step note's state backward",
+        commandName: 'Apply previous state',
         hotkey: { modifiers: ['Mod', 'Shift'], key: 'ArrowLeft' },
     },
     {
         commandId: 'project-browser:cycle-state-forward',
-        commandName: "Step note's state forward",
+        commandName: 'Apply next state',
         hotkey: { modifiers: ['Mod', 'Shift'], key: 'ArrowRight' },
     },
 ];
 
+const RECOMMENDED_COMMAND_NAMES = Object.fromEntries(
+    RECOMMENDED_HOTKEYS.map((recommendation) => [
+        recommendation.commandId,
+        recommendation.commandName,
+    ]),
+);
+
+const HOTKEY_KEY_LABELS: Record<string, string> = {
+    ArrowLeft: 'Left arrow',
+    ArrowRight: 'Right arrow',
+    ArrowUp: 'Up arrow',
+    ArrowDown: 'Down arrow',
+};
+
+const HOTKEY_APPLY_FAILURE_MESSAGE =
+    "If this persists, edit the hotkeys manually in the Obsidian Hotkeys settings.";
+
 export class RecommendedHotkeysModal extends Modal {
+    // Cached after load/apply so re-render reflects the latest state without reopening.
+    private hotkeyConfig: HotkeyConfig | null = null;
+
     constructor() {
         const { plugin } = getGlobals();
         super(plugin.app);
     }
 
     onOpen(): void {
-        this.titleEl.setText('Apply recommended hotkeys');
+        this.hotkeyConfig = null;
+        this.titleEl.setText('Recommended Hotkeys');
         void this.render();
     }
 
     onClose(): void {
         this.titleEl.empty();
         this.contentEl.empty();
+        this.hotkeyConfig = null;
     }
 
     private async render(): Promise<void> {
@@ -54,24 +79,16 @@ export class RecommendedHotkeysModal extends Modal {
         this.contentEl.empty();
 
         this.contentEl.createEl('p', {
-            text: 'Review each recommended hotkey before applying it. If a hotkey is already assigned elsewhere, you can override that one shortcut without changing the others.',
+            text: 'Apply the recommended hotkeys below.',
         });
 
         for (const recommendation of RECOMMENDED_HOTKEYS) {
             const conflict = this.findConflict(hotkeyConfig, recommendation);
             const isApplied = this.commandHasHotkey(hotkeyConfig, recommendation.commandId, recommendation.hotkey);
-            const commandName = commandNames[recommendation.commandId] ?? recommendation.commandName;
-            const hotkeyLabel = this.formatHotkey(recommendation.hotkey);
+            const statusText = this.getHotkeyStatusText(isApplied, conflict, commandNames);
 
-            new Setting(this.contentEl)
-                .setName(`${commandName}: ${hotkeyLabel}`)
-                .setDesc(
-                    isApplied
-                        ? 'Already applied.'
-                        : conflict
-                            ? `Conflicts with ${commandNames[conflict] ?? conflict}.`
-                            : 'No conflict found.',
-                )
+            const setting = new Setting(this.contentEl)
+                .setClass('ddc_pb_recommended-hotkey-setting')
                 .addButton((button) => {
                     button.setButtonText(isApplied ? 'Applied' : conflict ? 'Override' : 'Apply');
                     button.setDisabled(isApplied);
@@ -80,32 +97,110 @@ export class RecommendedHotkeysModal extends Modal {
                         void this.applyHotkey(recommendation);
                     });
                 });
+
+            setting.nameEl.empty();
+            setting.nameEl.setText(recommendation.commandName);
+
+            setting.descEl.empty();
+            // Line 2: accent chord, then faint bracketed status (applied / conflict / clear).
+            const hotkeyLineEl = setting.descEl.createDiv({ cls: 'ddc_pb_recommended-hotkey-line' });
+            this.renderHotkeyChord(hotkeyLineEl, recommendation.hotkey);
+            hotkeyLineEl.createSpan({
+                cls: 'ddc_pb_recommended-hotkey-status',
+                text: ` (${statusText})`,
+            });
         }
+    }
+
+    private getHotkeyStatusText(
+        isApplied: boolean,
+        conflict: string | null,
+        commandNames: Record<string, string>,
+    ): string {
+        if (isApplied) return 'Already applied.';
+        if (conflict) return `Conflicts with ${commandNames[conflict] ?? conflict}.`;
+        return 'No conflict found.';
+    }
+
+    private renderHotkeyChord(parentEl: HTMLElement, hotkey: ObsidianHotkey): void {
+        const hotkeyParts = this.getHotkeyDisplayParts(hotkey);
+        hotkeyParts.forEach((part, partIndex) => {
+            if (partIndex > 0) {
+                parentEl.createSpan({ cls: 'ddc_pb_recommended-hotkey-plus', text: ' + ' });
+            }
+            parentEl.createSpan({ cls: 'ddc_pb_recommended-hotkey-chord', text: part });
+        });
     }
 
     private async applyHotkey(recommendation: RecommendedHotkey): Promise<void> {
-        const hotkeyConfig = await this.loadHotkeyConfig();
+        try {
+            const hotkeyConfig = await this.loadHotkeyConfig();
+            const changedCommandIds: string[] = [];
 
-        // Obsidian stores custom hotkeys by command id. Remove the chosen chord from
-        // other commands first so applying a recommendation is a deliberate override.
-        for (const commandId of Object.keys(hotkeyConfig)) {
-            if (commandId === recommendation.commandId) continue;
-            hotkeyConfig[commandId] = hotkeyConfig[commandId].filter(
-                (hotkey) => !this.hotkeysMatch(hotkey, recommendation.hotkey),
-            );
-            if (hotkeyConfig[commandId].length === 0) {
-                delete hotkeyConfig[commandId];
+            for (const commandId of Object.keys(hotkeyConfig)) {
+                if (commandId === recommendation.commandId) continue;
+                // Deliberate override: strip this chord from other commands before assigning it here.
+                const filteredHotkeys = hotkeyConfig[commandId].filter(
+                    (hotkey) => !this.hotkeysMatch(hotkey, recommendation.hotkey),
+                );
+                if (filteredHotkeys.length === hotkeyConfig[commandId].length) continue;
+
+                if (filteredHotkeys.length === 0) {
+                    delete hotkeyConfig[commandId];
+                } else {
+                    hotkeyConfig[commandId] = filteredHotkeys;
+                }
+                changedCommandIds.push(commandId);
             }
-        }
 
-        hotkeyConfig[recommendation.commandId] = [recommendation.hotkey];
-        await this.saveHotkeyConfig(hotkeyConfig);
-        this.syncHotkeyManager(hotkeyConfig);
-        new Notice(`Applied ${this.formatHotkey(recommendation.hotkey)} to ${recommendation.commandName}.`);
-        await this.render();
+            hotkeyConfig[recommendation.commandId] = [recommendation.hotkey];
+            if (!changedCommandIds.includes(recommendation.commandId)) {
+                changedCommandIds.push(recommendation.commandId);
+            }
+
+            await this.saveHotkeyConfig(hotkeyConfig);
+            this.syncHotkeyManager(hotkeyConfig, changedCommandIds);
+
+            this.hotkeyConfig = JSON.parse(JSON.stringify(hotkeyConfig)) as HotkeyConfig;
+            new Notice(`Applied ${this.formatHotkeyForDisplay(recommendation.hotkey)} to ${recommendation.commandName}.`);
+            await this.render();
+        } catch (error) {
+            console.error('Failed to apply recommended hotkey', error);
+            new Notice(
+                `Couldn't apply ${this.formatHotkeyForDisplay(recommendation.hotkey)} to ${recommendation.commandName}. ${HOTKEY_APPLY_FAILURE_MESSAGE}`,
+                8000,
+            );
+            this.hotkeyConfig = null;
+            await this.render();
+        }
     }
 
     private async loadHotkeyConfig(): Promise<HotkeyConfig> {
+        if (this.hotkeyConfig) {
+            return JSON.parse(JSON.stringify(this.hotkeyConfig)) as HotkeyConfig;
+        }
+
+        const hotkeyConfig = await this.readHotkeyConfigFromSource();
+        this.hotkeyConfig = hotkeyConfig;
+        return JSON.parse(JSON.stringify(hotkeyConfig)) as HotkeyConfig;
+    }
+
+    private async readHotkeyConfigFromSource(): Promise<HotkeyConfig> {
+        const fromFile = await this.readHotkeyConfigFromFile();
+        const fromManager = this.readHotkeyConfigFromManager();
+        return { ...fromFile, ...fromManager };
+    }
+
+    private readHotkeyConfigFromManager(): HotkeyConfig {
+        const hotkeyManager = (this.app as typeof this.app & {
+            hotkeyManager?: { customKeys?: HotkeyConfig };
+        }).hotkeyManager;
+
+        if (!hotkeyManager?.customKeys) return {};
+        return JSON.parse(JSON.stringify(hotkeyManager.customKeys)) as HotkeyConfig;
+    }
+
+    private async readHotkeyConfigFromFile(): Promise<HotkeyConfig> {
         const { plugin } = getGlobals();
         const hotkeysPath = this.getHotkeysPath();
         if (!(await plugin.app.vault.adapter.exists(hotkeysPath))) {
@@ -131,22 +226,19 @@ export class RecommendedHotkeysModal extends Modal {
         return `${vault.configDir}/hotkeys.json`;
     }
 
-    private syncHotkeyManager(hotkeyConfig: HotkeyConfig): void {
+    private syncHotkeyManager(hotkeyConfig: HotkeyConfig, changedCommandIds: string[]): void {
+        // Obsidian exposes customKeys as read-only; setHotkeys + save is the supported sync path.
         const hotkeyManager = (this.app as typeof this.app & {
             hotkeyManager?: {
-                customKeys?: HotkeyConfig;
                 setHotkeys?: (commandId: string, hotkeys: ObsidianHotkey[]) => void;
                 save?: () => void;
             };
         }).hotkeyManager;
 
-        if (!hotkeyManager) return;
-        hotkeyManager.customKeys = hotkeyConfig;
-        for (const recommendation of RECOMMENDED_HOTKEYS) {
-            hotkeyManager.setHotkeys?.(
-                recommendation.commandId,
-                hotkeyConfig[recommendation.commandId] ?? [],
-            );
+        if (!hotkeyManager?.setHotkeys) return;
+
+        for (const commandId of changedCommandIds) {
+            hotkeyManager.setHotkeys(commandId, hotkeyConfig[commandId] ?? []);
         }
         hotkeyManager.save?.();
     }
@@ -159,7 +251,7 @@ export class RecommendedHotkeysModal extends Modal {
         return Object.fromEntries(
             Object.entries(commands).map(([commandId, command]) => [
                 commandId,
-                command.name ?? commandId,
+                RECOMMENDED_COMMAND_NAMES[commandId] ?? command.name ?? commandId,
             ]),
         );
     }
@@ -186,14 +278,41 @@ export class RecommendedHotkeysModal extends Modal {
     }
 
     private hotkeysMatch(left: ObsidianHotkey, right: ObsidianHotkey): boolean {
-        return left.key === right.key && this.normalizeModifiers(left).join('|') === this.normalizeModifiers(right).join('|');
+        return this.normalizeHotkeyKey(left.key) === this.normalizeHotkeyKey(right.key)
+            && this.normalizeModifiers(left).join('|') === this.normalizeModifiers(right).join('|');
+    }
+
+    private normalizeHotkeyKey(key: string): string {
+        if (key.length === 1) return key.toUpperCase();
+        return key;
     }
 
     private normalizeModifiers(hotkey: ObsidianHotkey): string[] {
-        return [...(hotkey.modifiers ?? [])].sort();
+        return [...(hotkey.modifiers ?? [])]
+            .map((modifier) => this.normalizeModifierForComparison(modifier))
+            .sort();
     }
 
-    private formatHotkey(hotkey: ObsidianHotkey): string {
-        return [...(hotkey.modifiers ?? []), hotkey.key].join('+');
+    private normalizeModifierForComparison(modifier: string): string {
+        // hotkeys.json may store Mod, Ctrl, or Meta for the same physical modifier.
+        if (modifier === 'Mod' || modifier === 'Ctrl' || modifier === 'Meta') {
+            return 'Mod';
+        }
+        return modifier;
+    }
+
+    private getHotkeyDisplayParts(hotkey: ObsidianHotkey): string[] {
+        const modifierLabels = (hotkey.modifiers ?? []).map((modifier) => {
+            if (modifier === 'Mod') {
+                return Platform.isMacOS ? 'Command' : 'Control';
+            }
+            return modifier;
+        });
+        const keyLabel = HOTKEY_KEY_LABELS[hotkey.key] ?? hotkey.key;
+        return [...modifierLabels, keyLabel];
+    }
+
+    private formatHotkeyForDisplay(hotkey: ObsidianHotkey): string {
+        return this.getHotkeyDisplayParts(hotkey).join('+');
     }
 }

--- a/src/tabs/settings-tab/settings-tab.ts
+++ b/src/tabs/settings-tab/settings-tab.ts
@@ -10,6 +10,7 @@ import { getGlobals } from "src/logic/stores";
 import { StateSettings } from "src/types/types-map";
 import { showWelcomeTips } from "src/notices/onboarding-notices";
 import { showRecentChanges } from "src/notices/version-notices";
+import { RecommendedHotkeysModal } from "src/modals/recommended-hotkeys-modal/recommended-hotkeys-modal";
 
 /////////
 /////////
@@ -177,6 +178,12 @@ function insertSetupTroubleshootSection(containerEl: HTMLElement) {
 			btn.setButtonText("Rewatch welcome tips");
 			btn.setCta();
 			btn.onClick(() => showWelcomeTips());
+		})
+		.addButton((btn) => {
+			btn.setButtonText("Apply recommended hotkeys");
+			btn.onClick(() => {
+				new RecommendedHotkeysModal().open();
+			});
 		});
 }
 

--- a/src/tabs/settings-tab/settings-tab.ts
+++ b/src/tabs/settings-tab/settings-tab.ts
@@ -180,7 +180,8 @@ function insertSetupTroubleshootSection(containerEl: HTMLElement) {
 			btn.onClick(() => showWelcomeTips());
 		})
 		.addButton((btn) => {
-			btn.setButtonText("Apply recommended hotkeys");
+			// Available on desktop and mobile (e.g. iPad with keyboard); opens RecommendedHotkeysModal.
+			btn.setButtonText("Recommended hotkeys");
 			btn.onClick(() => {
 				new RecommendedHotkeysModal().open();
 			});


### PR DESCRIPTION
## Summary

- Added a settings modal that lists recommended Project Browser hotkeys and reports conflicts from Obsidian's hotkeys config.
- Let users apply or override one recommended hotkey at a time instead of assigning shortcuts automatically.

## ClickUp

- [Apply recommended hotkeys](https://app.clickup.com/t/86d3by8hy) - `86d3by8hy`

## Test plan

- [x] `npm exec eslint -- src/modals/recommended-hotkeys-modal/recommended-hotkeys-modal.ts`
- [x] `npm run build`
- [x] `git diff --check`
- [ ] `npm run lint` (project-wide lint currently fails on existing files outside this change)
- [ ] `npm run test:unit` (project-wide unit suite currently fails in `src/logic/file-access-processes.test.ts` outside this change)

Made with [Cursor](https://cursor.com)