### PR TITLE
Project excerpt source page and PBS excerpt field

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ If you’re new to the codebase or the plugin’s mental model, start with **Ove
 ## Features
 
 - [Projects](projects.md): folders that behave like cards, and how project status works.
+- [Project excerpt source](project-excerpt-source.md): which markdown page feeds a project card preview, and the accent edge markers.
 - [State menu in the view header](state-menu-header.md): header state control and Tippy picker for notes, pages, and project roots.
 - [Project Pages FAB](project-pages-fab.md): the in-editor floating action button for jumping between project pages.
 - [File type visibility](file-type-visibility.md): control what file types appear in the Card Browser and in the pages menu.
@@ -31,4 +32,4 @@ If you’re new to the codebase or the plugin’s mental model, start with **Ove
 
 - **Understand the product**: Overview → Card Browser and navigation → States and sections
 - **Configure what you see**: Settings → File type visibility
-- **Understand “projects”**: Projects → Project Pages FAB
+- **Understand “projects”**: Projects → Project excerpt source → Project Pages FAB

--- a/docs/project-excerpt-source.md
+++ b/docs/project-excerpt-source.md
@@ -1,0 +1,67 @@
+# Project excerpt source
+
+Reference for how project cards choose their preview text, and how the active excerpt page is marked in the Card Browser and page menu.
+
+## Why it exists
+
+A project folder contains many files, so a project card cannot simply show “the note’s content” the way a single-note card can. Without an explicit rule, it was unclear which page fed the card preview. This feature picks a **markdown** page as the excerpt source (first alphabetically by default, or a user-chosen page) and makes that choice visible so you can tell at a glance which page the project card is summarizing.
+
+## Conceptual understanding
+
+- **Excerpt source** — The markdown page whose body is used for the project card’s blurb (after the same frontmatter/markdown cleanup as note excerpts).
+- **Default** — When no source is assigned, the first markdown page in page-menu sort order (natural alphabetical) is used.
+- **Assigned source** — Right-click a markdown page inside a project → **Set as excerpt source**. Choosing the same page again clears the assignment and returns to the alphabetical default.
+- **PBS `excerpt` field** — Optional markdown stored on the project itself in `folder-settings.pbs`. When non-empty, it overrides any page source for the card preview (intended for later synthesized summaries). In that case, no page shows the excerpt-source indicator.
+- **Markdown only** — Canvas, PDF, and other page-menu types cannot be set as excerpt sources and are never used for the default.
+
+## Flows
+
+```mermaid
+flowchart TD
+    A[Need project card excerpt] --> B{PBS excerpt field set?}
+    B -->|yes| C[Clean and show PBS excerpt]
+    B -->|no| D{excerptSource set and file exists?}
+    D -->|yes| E[Use that markdown page]
+    D -->|no| F[First markdown page alphabetically]
+    E --> G[Show page as excerpt source]
+    F --> G
+    C --> H[No page indicator]
+```
+
+### Assign or clear a source
+
+1. Open a project (Card Browser or page menu / note cards inside the project).
+2. Right-click a **markdown** page.
+3. Choose **Set as excerpt source** (checked when that page is already assigned).
+4. The choice is written to `folder-settings.pbs` as `excerptSource` (the file’s name, e.g. `Page 2.md`).
+5. Clicking the same item again clears `excerptSource`.
+
+## Visual indicators
+
+| Surface | Marker |
+|--------|--------|
+| Card Browser note card | 1px `--interactive-accent` line along the **top-right 20px** |
+| Page menu (FAB / sidebar) | 1px accent line on the **right** edge; when that page is also the selected (filled accent) row, the line is **white** so it stays visible |
+
+The indicator follows the **effective** page source (assigned or alphabetical default). It is hidden when the PBS `excerpt` field supplies the preview.
+
+## Technical details
+
+- Types: `FolderSettings_0_1_2.excerptSource?: string`, `excerpt?: string` (`src/types/folder-settings_0_1_2.ts`).
+- Resolution: `getProjectExcerpt` (`folder-processes.ts`) and `resolveProjectExcerptSourceFile` (`project-excerpt-source.ts`).
+- Persistence: `setFolderExcerptSource` writes PBS and calls `refreshFileDependants`.
+- Card outline refresh: cards are keyed by file path, so changing PBS does not remount them. `NoteCardBase` re-checks on `CardBrowserContext.refreshId`, and context-menu `onFileChange` calls `rerender()` so every card updates the outline without leaving the view.
+- Page menu: FAB and sidebar resolve the excerpt source path once per list refresh and pass `isExcerptSource` into `ProjectPageMenuFileButton`.
+
+## Technical Gotchas
+
+- **Markdown only** — Non-`.md` files never get the context-menu action or the indicator; alphabetical default skips them.
+- **Stale outlines without rerender** — Updating `isExcerptSource` only in the clicked card’s local state would leave the previous source outlined. Always bump browser `refreshId` (via `rerender` / file dependants) so all cards re-resolve.
+- **PBS `excerpt` vs page source** — A populated `excerpt` field wins for preview text and suppresses the page indicator even if `excerptSource` is still set.
+- **Name matching** — `excerptSource` stores `file.name` and matches by name or basename within the project’s page-menu file list.
+
+## Related
+
+- [Projects](projects.md) — Project conversion and PBS overview.
+- [Project Pages FAB](project-pages-fab.md) — Page list where the right-edge indicator appears.
+- [Card Browser and navigation](card-browser-and-navigation.md) — Where project cards and note cards render.

--- a/docs/project-pages-fab.md
+++ b/docs/project-pages-fab.md
@@ -100,7 +100,7 @@ The FAB and floating title are grouped in the bottom-right corner of the window:
 - **Page list**: Derived from `getItemsInFolder(projectFolder)` — filtered to `TFile`, filtered by visible file types (`isExtensionVisible`), sorted by name.
 - **Page button labels**: Use `getFileDisplayNameParts()`, which respects the "Show extension for non-document files" setting. The extension portion is faded with `--text-faint`. Only canvas and base files show a type tag (CANVAS, BASE) at the top-right of each button; other file types do not.
 - **Page button height**: FAB page buttons (`.ddc_pb_project-page-menu__file-button--fab`) set `height: auto` and `max-height: none` so Obsidian’s default fixed button height does not clip wrapped titles after the second line.
-- **Context menu**: Right-click a page button for the same file-type-specific options as the card browser: Open in new tab, Priorities/States (notes only), Rename, Delete. See [file-type-visibility.md](file-type-visibility.md) for details.
+- **Context menu**: Right-click a page button for the same file-type-specific options as the card browser: Open in new tab, Priorities/States (notes only), **Set as excerpt source** (markdown pages in a project), Rename, Delete. See [file-type-visibility.md](file-type-visibility.md) and [project-excerpt-source.md](project-excerpt-source.md).
 - **Navigation**: Uses `openFileInSameLeaf` followed by `openStateMenuIfClosed`.
 - **Navigation menu state**: Page-to-page navigation keeps the menu open so users can continue navigating without reopening it.
 - **State sync on page switch**: FAB/state header refreshes on both active-leaf changes and file-open events for the active file view, so selected-page highlighting and related header state update correctly when switching files in the same leaf (including markdown, canvas, and base transitions).
@@ -120,3 +120,8 @@ The FAB and floating title are grouped in the bottom-right corner of the window:
 - **Embed content** — Clicks inside transcluded or embedded content close the menu, since those elements are part of the document and the `pointerdown` target is outside the FAB.
 - **Page list edge fades** — Fades use mask alpha (a true opacity falloff of the list), not a solid colour overlay. When the list does not overflow, both fades are off so short lists do not get softened edges.
 - **Wrapped titles vs Obsidian button height** — Enabling wrap alone is not enough: Obsidian buttons keep a fixed height that clips about two lines. Override with `height: auto` / `max-height: none` so the chip grows with the full page name.
+
+## Related
+
+- [Projects](projects.md) — Converting folders to projects and PBS overview.
+- [Project excerpt source](project-excerpt-source.md) — Assigning which markdown page feeds the project card preview; right-edge accent on the source page in this menu.

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -60,11 +60,15 @@ flowchart TB
 
 On a project root, the Card Browser leaf title shows the project name (instead of **Browse**) on the line above that header control. Details: [State menu in the view header](state-menu-header.md).
 
+### Project card excerpt
+
+Project cards show a text preview drawn from a markdown page in the project (or from an optional PBS `excerpt` field). By default that is the first markdown page alphabetically; you can assign a different page with **Set as excerpt source**. Details: [Project excerpt source](project-excerpt-source.md).
+
 ## Technical implementation
 
 - Project status is stored in `folder-settings.pbs` inside each folder.
-- `FolderSettings_0_1_2` defines `isProject?: boolean` and `stateName?: string`.
-- `stateName` matches `StateSettings.name`; when absent, the project is stateless.
+- `FolderSettings_0_1_2` defines `isProject?: boolean`, `state?: string`, plus optional `excerptSource` / `excerpt` for card previews.
+- `state` matches `StateSettings.name`; when absent, the project is stateless.
 - Project cards match note card styling, with a thicker top border for visual distinction.
 - Section building is async (`getSortedSectionsInFolderAsync`) because it reads folder settings from disk.
 
@@ -78,4 +82,5 @@ On a project root, the Card Browser leaf title shows the project name (instead o
 
 - [States and sections](states-and-sections.md) — How visible/hidden states and the No status section work.
 - [State menu in the view header](state-menu-header.md) — Header control and Tippy picker for notes, pages, and project roots.
+- [Project excerpt source](project-excerpt-source.md) — Which page feeds the project card preview and how it is marked in the UI.
 - [Project Pages FAB](project-pages-fab.md) — Floating action button for quick navigation between pages when viewing a note inside a project.

--- a/src/components/card-browser/card-browser.tsx
+++ b/src/components/card-browser/card-browser.tsx
@@ -22,12 +22,18 @@ import { ProjectFolderStateMenu } from '../state-menu/project-folder-state-menu'
 export const CardBrowserContext = React.createContext<{
     folder: null | TFolder,
     lastTouchedFilePath: string,
+    /**
+     * Bumps when the browser reloads so cards can re-check excerpt-source indicators.
+     * Cards are keyed by file path, so PBS-only changes would otherwise leave stale outlines.
+     */
+    refreshId: string,
     rememberLastTouchedFile: (file: TFile) => void,
     openFolderInSameLeaf: (folder: TFolder) => void,
     rerender: () => void,
 }>({
     folder: null,
     lastTouchedFilePath: '',
+    refreshId: '',
     rememberLastTouchedFile: () => {},
     openFolderInSameLeaf: () => {},
     rerender: () => {},
@@ -178,6 +184,7 @@ export const CardBrowser = (props: CardBrowserProps) => {
         <CardBrowserContext.Provider value={{
             folder: initialFolder,
             lastTouchedFilePath,
+            refreshId,
             openFolderInSameLeaf,
             rememberLastTouchedFile,
             rerender,

--- a/src/components/cards/note-card-base/note-card-base.scss
+++ b/src/components/cards/note-card-base/note-card-base.scss
@@ -71,6 +71,21 @@
     .ddc_pb_file-ext-faint {
         color: var(--text-faint, rgba(255, 255, 255, 0.4));
     }
+
+    // Top-right 20px outline marks the markdown page that supplies this project's card excerpt.
+    &.ddc_pb_excerpt-source::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: auto;
+        width: 20px;
+        height: 0;
+        border-top: 1px solid var(--interactive-accent);
+        border-radius: 0 8px 0 0;
+        pointer-events: none;
+        z-index: 1;
+    }
 }
 
 .ddc_pb_priorities-visible .ddc_pb_note-card-base {

--- a/src/components/cards/note-card-base/note-card-base.tsx
+++ b/src/components/cards/note-card-base/note-card-base.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import './note-card-base.scss';
-import { TFile } from "obsidian";
+import { TFile, TFolder } from "obsidian";
 import * as React from "react";
 import { registerFileContextMenu } from 'src/context-menus/file-context-menu';
 import { CardBrowserContext } from 'src/components/card-browser/card-browser';
@@ -9,6 +9,8 @@ import { openFileInBackgroundTab, openFileInSameLeaf } from 'src/logic/file-acce
 import { getFilePrioritySettings } from 'src/logic/frontmatter-processes';
 import { getFileTypeLabel } from 'src/logic/get-file-type-label';
 import { isExtensionUnsupportedByObsidian } from 'src/logic/is-extension-unsupported';
+import { isFileProjectExcerptSource } from 'src/logic/project-excerpt-source';
+import { getFolderSettings } from 'src/utils/file-manipulation';
 import { ExternalLink } from 'lucide-react';
 
 /////////
@@ -27,6 +29,7 @@ export const NoteCardBase = (props: NoteCardBaseProps) => {
     const {plugin} = getGlobals();
     const cardBrowserContext = React.useContext(CardBrowserContext);
     const noteRef = React.useRef(null);
+    const [isExcerptSource, setIsExcerptSource] = React.useState(false);
 
     const prioritySettings = getFilePrioritySettings(props.file);
     const showSettleTransition = props.file.path === cardBrowserContext.lastTouchedFilePath;
@@ -40,9 +43,34 @@ export const NoteCardBase = (props: NoteCardBaseProps) => {
             file: props.file,
             onFileChange: () => {
                 cardBrowserContext.rememberLastTouchedFile(props.file);
+                // PBS excerpt-source changes don't remount cards by path; force a browser refresh
+                // so every card re-evaluates its outline.
+                cardBrowserContext.rerender();
             },
         });
     }, [])
+
+    React.useEffect(() => {
+        let cancelled = false;
+        async function refreshExcerptSourceIndicator() {
+            const parent = props.file.parent;
+            if (!(parent instanceof TFolder)) {
+                if (!cancelled) setIsExcerptSource(false);
+                return;
+            }
+            const folderSettings = await getFolderSettings(plugin.app.vault, parent);
+            if (!folderSettings.isProject) {
+                if (!cancelled) setIsExcerptSource(false);
+                return;
+            }
+            const isSource = await isFileProjectExcerptSource(props.file, parent);
+            if (!cancelled) setIsExcerptSource(isSource);
+        }
+        void refreshExcerptSourceIndicator();
+        return () => {
+            cancelled = true;
+        };
+    }, [props.file.path, plugin, cardBrowserContext.refreshId]);
     
     return <>
         <article
@@ -52,7 +80,8 @@ export const NoteCardBase = (props: NoteCardBaseProps) => {
                 props.className,
                 prioritySettings?.name.includes('High') && 'ddc_pb_high-priority',
                 prioritySettings?.name.includes('Low') && 'ddc_pb_low-priority',
-                showSettleTransition && 'ddc_pb_closing'
+                showSettleTransition && 'ddc_pb_closing',
+                isExcerptSource && 'ddc_pb_excerpt-source',
             ])}
             onClick = { (event) => {
                 if (event.ctrlKey || event.metaKey) {
@@ -85,4 +114,4 @@ export const NoteCardBase = (props: NoteCardBaseProps) => {
             {props.children}
         </article>
     </>
-} 
+}

--- a/src/components/project-page-menu-file-button/project-page-menu-file-button.tsx
+++ b/src/components/project-page-menu-file-button/project-page-menu-file-button.tsx
@@ -14,6 +14,8 @@ export interface ProjectPageMenuFileButtonProps {
     context: 'fab' | 'sidebar';
     onPageClick: (file: TFile) => void;
     onFileChange: () => void;
+    /** True when this markdown page is the project's active excerpt source. */
+    isExcerptSource?: boolean;
 }
 
 export const ProjectPageMenuFileButton = (props: ProjectPageMenuFileButtonProps) => {
@@ -40,7 +42,8 @@ export const ProjectPageMenuFileButton = (props: ProjectPageMenuFileButtonProps)
             className={classNames(
                 'ddc_pb_project-page-menu__file-button',
                 `ddc_pb_project-page-menu__file-button--${props.context}`,
-                props.isCurrentPage && 'ddc_pb_project-page-menu__file-button--active'
+                props.isCurrentPage && 'ddc_pb_project-page-menu__file-button--active',
+                props.isExcerptSource && 'ddc_pb_excerpt-source',
             )}
             onClick={props.isCurrentPage ? undefined : () => props.onPageClick(props.file)}
             disabled={props.isCurrentPage}

--- a/src/components/project-pages-fab/project-pages-fab.scss
+++ b/src/components/project-pages-fab/project-pages-fab.scss
@@ -153,11 +153,29 @@
         .ddc_pb_file-ext-faint {
             color: var(--text-faint, rgba(255, 255, 255, 0.4));
         }
+
+        // Right-edge outline marks the markdown page that supplies the project card excerpt.
+        &.ddc_pb_excerpt-source::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            width: 0;
+            border-right: 1px solid var(--interactive-accent);
+            border-radius: 0 8px 8px 0;
+            pointer-events: none;
+        }
     }
 
     .ddc_pb_project-page-menu__file-button--fab.ddc_pb_project-page-menu__file-button--active {
         cursor: default;
         background-color: var(--interactive-accent);
+
+        // Light edge so the excerpt marker stays visible on the filled accent background.
+        &.ddc_pb_excerpt-source::after {
+            border-right-color: #fff;
+        }
 
         &:disabled {
             opacity: 1;

--- a/src/components/project-pages-fab/project-pages-fab.tsx
+++ b/src/components/project-pages-fab/project-pages-fab.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, FileStack, Plus } from 'lucide-react';
 import classNames from 'classnames';
 import { ProjectPageMenuFileButton } from 'src/components/project-page-menu-file-button/project-page-menu-file-button';
 import { getSortedPageMenuFilesInProjectFolder } from 'src/logic/project-page-list';
+import { resolveProjectExcerptSourceFile } from 'src/logic/project-excerpt-source';
 import { isRootPath } from 'src/utils/string-processes';
 import {
     FabMenuActionButton,
@@ -50,6 +51,18 @@ export const ProjectPagesFAB = (props: ProjectPagesFABProps) => {
     const pagesInProject = React.useMemo(() => {
         void refreshTrigger;
         return getSortedPageMenuFilesInProjectFolder(props.projectFolder);
+    }, [props.projectFolder, refreshTrigger]);
+
+    const [excerptSourcePath, setExcerptSourcePath] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        let cancelled = false;
+        void resolveProjectExcerptSourceFile(props.projectFolder).then((sourceFile) => {
+            if (!cancelled) setExcerptSourcePath(sourceFile?.path ?? null);
+        });
+        return () => {
+            cancelled = true;
+        };
     }, [props.projectFolder, refreshTrigger]);
 
     React.useEffect(() => {
@@ -213,6 +226,7 @@ export const ProjectPagesFAB = (props: ProjectPagesFABProps) => {
                                 context="fab"
                                 onPageClick={handlePageClick}
                                 onFileChange={() => setRefreshTrigger((t) => t + 1)}
+                                isExcerptSource={file.path === excerptSourcePath}
                             />
                         ))}
                     </div>

--- a/src/context-menus/file-context-menu.tsx
+++ b/src/context-menus/file-context-menu.tsx
@@ -10,6 +10,7 @@ import { getGlobals } from "src/logic/stores";
 import { RenameFileModal } from "src/modals/rename-file-modal/rename-file-modal";
 import { PrioritySettings, StateSettings } from "src/types/types-map";
 import { getFolderSettings, setFolderExcerptSource } from "src/utils/file-manipulation";
+import { isMarkdownFile } from "src/logic/project-excerpt-source";
 
 ////////
 ////////
@@ -45,7 +46,8 @@ export function registerFileContextMenu(props: registerFileContextMenuProps) {
         let projectFolder = props.file.parent;
         let canSetExcerptSource = false;
         let isCurrentExcerptSource = false;
-        if (projectFolder) {
+        // Excerpt sources are markdown-only; canvas/base/etc. stay out of the menu.
+        if (projectFolder && isMarkdownFile(props.file)) {
             const folderSettings = await getFolderSettings(plugin.app.vault, projectFolder);
             canSetExcerptSource = !!folderSettings.isProject;
             isCurrentExcerptSource =

--- a/src/context-menus/file-context-menu.tsx
+++ b/src/context-menus/file-context-menu.tsx
@@ -9,6 +9,7 @@ import { revealInProjectBrowser } from "src/logic/reveal-in-project-browser";
 import { getGlobals } from "src/logic/stores";
 import { RenameFileModal } from "src/modals/rename-file-modal/rename-file-modal";
 import { PrioritySettings, StateSettings } from "src/types/types-map";
+import { getFolderSettings, setFolderExcerptSource } from "src/utils/file-manipulation";
 
 ////////
 ////////
@@ -40,6 +41,17 @@ export function registerFileContextMenu(props: registerFileContextMenuProps) {
         visibleStates.reverse();
         const hiddenStates = JSON.parse(JSON.stringify(scopedStateSettings.hidden));
         hiddenStates.reverse();
+
+        let projectFolder = props.file.parent;
+        let canSetExcerptSource = false;
+        let isCurrentExcerptSource = false;
+        if (projectFolder) {
+            const folderSettings = await getFolderSettings(plugin.app.vault, projectFolder);
+            canSetExcerptSource = !!folderSettings.isProject;
+            isCurrentExcerptSource =
+                folderSettings.excerptSource === props.file.name ||
+                folderSettings.excerptSource === props.file.basename;
+        }
         
         const menu = new Menu();
         if (!isUnsupported) {
@@ -100,6 +112,20 @@ export function registerFileContextMenu(props: registerFileContextMenuProps) {
                 });
             })
             menu.addSeparator();
+        }
+        if (canSetExcerptSource && projectFolder) {
+            menu.addItem((item) => {
+                item.setTitle('Set as excerpt source');
+                if (isCurrentExcerptSource) item.setChecked(true);
+                item.onClick(async () => {
+                    // Toggle off when re-selecting the current source so projects fall back to alphabetical default.
+                    await setFolderExcerptSource(
+                        projectFolder!,
+                        isCurrentExcerptSource ? null : props.file,
+                    );
+                    props.onFileChange();
+                });
+            });
         }
         menu.addItem((item) =>
             item.setTitle("Rename")

--- a/src/logic/folder-processes.ts
+++ b/src/logic/folder-processes.ts
@@ -6,6 +6,14 @@ import { getGlobals } from "./stores";
 import { getFolderSettings, getFolderStateName } from "src/utils/file-manipulation";
 import { isExtensionVisible } from "./file-type-filter";
 import { FileStateScope } from "./project-page-states";
+import { getSortedPageMenuFilesInProjectFolder } from "./project-page-list";
+import {
+    removeCodeBlocks,
+    removeFrontmatter,
+    removeMarkdownCharacters,
+    removeXmlTags,
+    simplifyWhiteSpace,
+} from "src/utils/string-processes";
 
 ///////////
 ///////////
@@ -70,20 +78,36 @@ function getProjectState(folder: TFolder): null | string {
 }
 
 export const getProjectExcerpt = async (folder: TFolder): Promise<null|string> => {
-    const itemsInFolder = getItemsInFolder(folder);
-    if(!itemsInFolder)  return null;
-    
-    for(let i=0; i<itemsInFolder.length; i++) {
-        const item = itemsInFolder[i];
-        if(item instanceof TFile) {
-            const rawState = getFileStateSettings(item);
-            if(rawState) {
-                return await getFileExcerpt(item);
-            }
+    const { plugin } = getGlobals();
+    const folderSettings = await getFolderSettings(plugin.app.vault, folder);
+
+    // PBS-stored markdown excerpt wins when present (synthesized / manual project summary).
+    if (folderSettings.excerpt && folderSettings.excerpt.trim()) {
+        let excerpt = folderSettings.excerpt;
+        excerpt = removeFrontmatter(excerpt);
+        excerpt = removeCodeBlocks(excerpt);
+        excerpt = removeXmlTags(excerpt);
+        excerpt = removeMarkdownCharacters(excerpt);
+        excerpt = simplifyWhiteSpace(excerpt);
+        return excerpt || null;
+    }
+
+    const pages = getSortedPageMenuFilesInProjectFolder(folder);
+    if (pages.length === 0) return null;
+
+    // Prefer an explicitly assigned excerpt source page when it still exists in the project.
+    if (folderSettings.excerptSource) {
+        const sourceName = folderSettings.excerptSource;
+        const sourceFile = pages.find(
+            (file) => file.name === sourceName || file.basename === sourceName,
+        );
+        if (sourceFile) {
+            return await getFileExcerpt(sourceFile);
         }
     }
 
-    return null;
+    // Default: first page alphabetically (same ordering as the project page menu).
+    return await getFileExcerpt(pages[0]);
 }
 
 export const getSortedSectionsInFolder = (folder: TFolder): Section[] => {

--- a/src/logic/folder-processes.ts
+++ b/src/logic/folder-processes.ts
@@ -6,7 +6,7 @@ import { getGlobals } from "./stores";
 import { getFolderSettings, getFolderStateName } from "src/utils/file-manipulation";
 import { isExtensionVisible } from "./file-type-filter";
 import { FileStateScope } from "./project-page-states";
-import { getSortedPageMenuFilesInProjectFolder } from "./project-page-list";
+import { getSortedMarkdownPagesInProjectFolder } from "./project-excerpt-source";
 import {
     removeCodeBlocks,
     removeFrontmatter,
@@ -92,7 +92,8 @@ export const getProjectExcerpt = async (folder: TFolder): Promise<null|string> =
         return excerpt || null;
     }
 
-    const pages = getSortedPageMenuFilesInProjectFolder(folder);
+    // Only markdown pages can supply project card excerpts.
+    const pages = getSortedMarkdownPagesInProjectFolder(folder);
     if (pages.length === 0) return null;
 
     // Prefer an explicitly assigned excerpt source page when it still exists in the project.
@@ -106,7 +107,7 @@ export const getProjectExcerpt = async (folder: TFolder): Promise<null|string> =
         }
     }
 
-    // Default: first page alphabetically (same ordering as the project page menu).
+    // Default: first markdown page alphabetically (same ordering as the project page menu).
     return await getFileExcerpt(pages[0]);
 }
 

--- a/src/logic/project-excerpt-source.ts
+++ b/src/logic/project-excerpt-source.ts
@@ -1,0 +1,49 @@
+import { TFile, TFolder } from 'obsidian';
+import { getSortedPageMenuFilesInProjectFolder } from './project-page-list';
+import { getFolderSettings } from 'src/utils/file-manipulation';
+import { getGlobals } from './stores';
+
+//////////////////
+//////////////////
+
+export function isMarkdownFile(file: TFile): boolean {
+	return (file.extension ?? '').toLowerCase() === 'md';
+}
+
+/** Markdown pages in a project, sorted the same way as the page menu. */
+export function getSortedMarkdownPagesInProjectFolder(folder: TFolder): TFile[] {
+	return getSortedPageMenuFilesInProjectFolder(folder).filter(isMarkdownFile);
+}
+
+/**
+ * Returns the markdown page that currently supplies the project card excerpt, or null when
+ * the PBS `excerpt` field is used / no markdown pages exist.
+ */
+export async function resolveProjectExcerptSourceFile(folder: TFolder): Promise<TFile | null> {
+	const { plugin } = getGlobals();
+	const folderSettings = await getFolderSettings(plugin.app.vault, folder);
+
+	// Synthesized / manual PBS excerpt means no page is the active source for the indicator.
+	if (folderSettings.excerpt && folderSettings.excerpt.trim()) {
+		return null;
+	}
+
+	const markdownPages = getSortedMarkdownPagesInProjectFolder(folder);
+	if (markdownPages.length === 0) return null;
+
+	if (folderSettings.excerptSource) {
+		const sourceName = folderSettings.excerptSource;
+		const sourceFile = markdownPages.find(
+			(file) => file.name === sourceName || file.basename === sourceName,
+		);
+		if (sourceFile) return sourceFile;
+	}
+
+	return markdownPages[0];
+}
+
+export async function isFileProjectExcerptSource(file: TFile, projectFolder: TFolder): Promise<boolean> {
+	if (!isMarkdownFile(file)) return false;
+	const sourceFile = await resolveProjectExcerptSourceFile(projectFolder);
+	return !!sourceFile && sourceFile.path === file.path;
+}

--- a/src/types/folder-settings_0_1_2.ts
+++ b/src/types/folder-settings_0_1_2.ts
@@ -6,6 +6,16 @@ export interface FolderSettings_0_1_2 {
     isProject?: boolean,
     state?: string,
     priority?: string,
+    /**
+     * Project-card excerpt source: basename of a page in this folder (e.g. `Page 1.md`).
+     * When unset, the first page alphabetically is used.
+     */
+    excerptSource?: string,
+    /**
+     * Optional markdown excerpt stored on the project itself (for synthesized summaries later).
+     * When set, this takes priority over `excerptSource` / alphabetical default for card previews.
+     */
+    excerpt?: string,
 }
 
 export const DEFAULT_FOLDER_SETTINGS_0_1_2: FolderSettings_0_1_2 = {

--- a/src/types/folder-settings_0_1_2.ts
+++ b/src/types/folder-settings_0_1_2.ts
@@ -7,8 +7,8 @@ export interface FolderSettings_0_1_2 {
     state?: string,
     priority?: string,
     /**
-     * Project-card excerpt source: basename of a page in this folder (e.g. `Page 1.md`).
-     * When unset, the first page alphabetically is used.
+     * Project-card excerpt source: basename of a markdown page in this folder (e.g. `Page 1.md`).
+     * When unset, the first markdown page alphabetically is used.
      */
     excerptSource?: string,
     /**

--- a/src/utils/file-manipulation.ts
+++ b/src/utils/file-manipulation.ts
@@ -444,6 +444,19 @@ export async function setFolderPriority(folder: TFolder, prioritySettings: Prior
     void plugin.refreshFileDependants();
 }
 
+/** Saves which project page supplies the card excerpt preview (stored as the file's name). */
+export async function setFolderExcerptSource(folder: TFolder, sourceFile: TFile | null): Promise<void> {
+    const {plugin} = getGlobals();
+    const folderSettings = await getFolderSettings(plugin.app.vault, folder);
+    if (sourceFile === null) {
+        delete folderSettings.excerptSource;
+    } else {
+        folderSettings.excerptSource = sourceFile.name;
+    }
+    await saveFolderSettings(plugin.app.vault, folder, folderSettings);
+    void plugin.refreshFileDependants();
+}
+
 export async function getFolderStateName(folder: TFolder): Promise<string | null> {
     const {plugin} = getGlobals();
     const folderSettings = await getFolderSettings(plugin.app.vault, folder);

--- a/src/utils/file-manipulation.ts
+++ b/src/utils/file-manipulation.ts
@@ -444,12 +444,14 @@ export async function setFolderPriority(folder: TFolder, prioritySettings: Prior
     void plugin.refreshFileDependants();
 }
 
-/** Saves which project page supplies the card excerpt preview (stored as the file's name). */
+/** Saves which project page supplies the card excerpt preview (stored as the file's name). Markdown only. */
 export async function setFolderExcerptSource(folder: TFolder, sourceFile: TFile | null): Promise<void> {
     const {plugin} = getGlobals();
     const folderSettings = await getFolderSettings(plugin.app.vault, folder);
     if (sourceFile === null) {
         delete folderSettings.excerptSource;
+    } else if ((sourceFile.extension ?? '').toLowerCase() !== 'md') {
+        return;
     } else {
         folderSettings.excerptSource = sourceFile.name;
     }

--- a/src/views/project-pages-sidebar-view/project-pages-sidebar-view.scss
+++ b/src/views/project-pages-sidebar-view/project-pages-sidebar-view.scss
@@ -130,6 +130,24 @@
 	background-color: rgba(0, 0, 0, 0.28) !important;
 }
 
+/* Right-edge outline marks the markdown page that supplies the project card excerpt. */
+.ddc_pb_project-pages-sidebar__list .ddc_pb_project-page-menu__file-button--sidebar.ddc_pb_excerpt-source::after {
+	content: '';
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: 0;
+	border-right: 1px solid var(--interactive-accent);
+	border-radius: 0 8px 8px 0;
+	pointer-events: none;
+}
+
+/* Light edge so the excerpt marker stays visible on the filled accent background. */
+.ddc_pb_project-pages-sidebar__list .ddc_pb_project-page-menu__file-button--sidebar.ddc_pb_excerpt-source.ddc_pb_project-page-menu__file-button--active::after {
+	border-right-color: #fff;
+}
+
 .ddc_pb_project-pages-sidebar__footer {
 	flex-shrink: 0;
 	width: 100%;

--- a/src/views/project-pages-sidebar-view/project-pages-sidebar-view.tsx
+++ b/src/views/project-pages-sidebar-view/project-pages-sidebar-view.tsx
@@ -11,6 +11,7 @@ import { ProjectPageMenuFileButton } from 'src/components/project-page-menu-file
 import { ICON_PLUGIN } from 'src/constants';
 import { openFileInMostRecentRootLeaf, openNewPageAndSelectTitle } from 'src/logic/file-access-processes';
 import { getSortedPageMenuFilesInProjectFolder } from 'src/logic/project-page-list';
+import { resolveProjectExcerptSourceFile } from 'src/logic/project-excerpt-source';
 import { syncProjectPagesSidebarFromActiveWorkspaceContext } from 'src/logic/project-pages-sidebar-controller';
 import { getGlobals } from 'src/logic/stores';
 import { openStateMenuIfClosed } from 'src/logic/toggle-state-menu';
@@ -107,6 +108,22 @@ export const ProjectPagesSidebarContent = (props: SidebarContentProps) => {
         return getSortedPageMenuFilesInProjectFolder(props.projectFolder);
     }, [props.projectFolder, listRefreshToken]);
 
+    const [excerptSourcePath, setExcerptSourcePath] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        let cancelled = false;
+        if (!props.projectFolder) {
+            setExcerptSourcePath(null);
+            return;
+        }
+        void resolveProjectExcerptSourceFile(props.projectFolder).then((sourceFile) => {
+            if (!cancelled) setExcerptSourcePath(sourceFile?.path ?? null);
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [props.projectFolder, listRefreshToken]);
+
     if (!props.projectFolder) {
         return (
             <div className="ddc_pb_project-pages-sidebar">
@@ -163,6 +180,7 @@ export const ProjectPagesSidebarContent = (props: SidebarContentProps) => {
                                     context="sidebar"
                                     onPageClick={handlePageClick}
                                     onFileChange={() => setListRefreshToken((v) => v + 1)}
+                                    isExcerptSource={file.path === excerptSourcePath}
                                 />
                             </li>
                         ))}


### PR DESCRIPTION
## Summary

- Project card excerpts now default to the first page alphabetically (page-menu order) instead of the first file that happens to have a state.
- Right-click a page inside a project → Set as excerpt source stores the page name in `folder-settings.pbs`; selecting it again clears the override.
- Extended the PBS schema with an optional `excerpt` markdown field that, when present, is used for the project card preview ahead of any page source.

## ClickUp

- [Projects need an excerpt page you can assign](https://app.clickup.com/t/86d2d61j3) - `86d2d61j3` (list: `PB: 0.5`)

## Test plan

- [x] `npm run build`
- [ ] Open Card Browser detailed project cards; confirm excerpt comes from the alphabetically first page when unset
- [ ] Right-click a later page → Set as excerpt source; confirm the project card updates
- [ ] Right-click again to clear; confirm fallback to alphabetical first page
- [ ] Manually set `excerpt` in a project's PBS file and confirm the card uses that text

## Stack

Base: `release_0.5`
Depends on: none

Made with [Cursor](https://cursor.com)